### PR TITLE
Added Class Implementations For Queue

### DIFF
--- a/kernel/include/event_loop.h
+++ b/kernel/include/event_loop.h
@@ -1,16 +1,17 @@
+// Citations
+// https://stackoverflow.com/questions/51837684/c-save-lambda-functions-as-member-variables-without-function-pointers-for-opti
+
 #ifndef EVENT_LOOP_H
 #define EVENT_LOOP_H
 
-// Dependencies
-struct Queue;
+#include "queue.h"
 
-typedef void (*Work)(void *);
+extern void event_loop();
 
-typedef struct {
-  Work work;
-} Event;
-
-void event_loop(struct Queue *queue);
-void event_loop_test();
+struct Event
+{
+  virtual void run() = 0;
+  virtual ~Event();
+};
 
 #endif // EVENT_LOOP_H

--- a/kernel/include/queue.h
+++ b/kernel/include/queue.h
@@ -1,26 +1,48 @@
 #ifndef QUEUE_H
 #define QUEUE_H
 
-////////////////////////////////////
-// A generic queue implementation //
-////////////////////////////////////
+#include "atomics.h"
 
-// Note: only supports single-core, no locks, uses linked list structure
-// Todo: change to lock-less queue for multi-cores
+template <typename T>
+class LocklessQueue
+{
+  struct Node
+  {
+    T item;
+    Atomic<Node*> next; 
+  };
 
-typedef struct Node {
-  void* item;
-  struct Node *next;
-} Node;
+  Atomic<Node*> head;
+  Atomic<Node*> tail;
 
-typedef struct Queue {
-  Node *head;
-  Node *tail;
-} Queue;
+public:
+  
+  LocklessQueue();
+  ~LocklessQueue();
+  void enqueue(T item);
+  T dequeue();
+  bool is_empty();
+};
 
-void init_queue(Queue *queue);
-void enqueue(Queue *queue, void *item);
-void *dequeue(Queue *queue);
-int empty(Queue *queue);
+template <typename T>
+class Queue
+{
+  struct Node
+  {
+    T item; 
+    Node* next;
+  };
+
+  Node* head;
+  Node* tail;
+
+public:
+
+  Queue();
+  ~Queue();
+  void enqueue(T item);
+  T dequeue();
+  bool is_empty();
+};
 
 #endif // QUEUE_H

--- a/kernel/src/event_loop.cpp
+++ b/kernel/src/event_loop.cpp
@@ -3,31 +3,9 @@
 #include "queue.h"
 #include "debug.h"
 
-void event_loop(Queue *queue) {
-  debug_print("Entering event loop!\n");
-  while (!empty(queue)) {
-    Work event = (Work) dequeue(queue);
-    event(0);
+void event_loop() {
+  while (true)
+  {
+    
   }
-}
-
-void fun1(void *args) {
-  debug_print("In fun1()\n");
-}
-
-void fun2(void *args) {
-  debug_print("In fun2(), calling fun1()\n");
-  fun1(0);
-}
-
-void event_loop_test() {
-  // Rudimentary test
-  // Don't have malloc so have to do sketchy stuff
-  Queue queue;
-
-  Node fun2_node = { (void*)fun2, nullptr };
-  Node fun1_node = { (void*)fun1, &fun2_node };
-  queue.head = &fun1_node;
-
-  event_loop(&queue);
 }

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -13,8 +13,7 @@ extern "C" void kernelMain()
   debug_print("DingOS is Booting!\n");
 
 
-
-  event_loop_test();
+  event_loop();
 
   // while(1);
 }

--- a/kernel/src/queue.cpp
+++ b/kernel/src/queue.cpp
@@ -1,32 +1,93 @@
 #include "queue.h"
 
-void init_queue(Queue *queue) {
-  queue->head = queue->tail = 0;
+// Lockless Queue Implementation
+
+template <typename T>
+LocklessQueue<T>::LocklessQueue()
+{
+  head.store(0);
 }
 
-void enqueue(Queue *queue, void *item) {
+template <typename T>
+LocklessQueue<T>::~LocklessQueue()
+{
+  // TODO: requires free here
+}
+
+template <typename T>
+void LocklessQueue<T>::enqueue(T item)
+{
   // TODO: requires malloc here
 }
 
-void *dequeue(Queue *queue) {
-  if (queue->head == 0)
-    return 0;
+template <typename T>
+T LocklessQueue<T>::dequeue()
+{
+  bool successful_exchange;
+  Node* temp;
 
-  // Pop a node
-  Node *temp = queue->head;
-  queue->head = (Node *) queue->head->next;
-  void *item = temp->item;
+  do 
+  {
+    temp = head.load();
 
-  // If head is NULL, reset tail
-  if (queue->head == 0)
-    queue->tail = 0;
+    if (temp == 0)
+      break;
+    else
+      successful_exchange = head.compare_exchange(temp, temp->next.load()); // can be improved with better atomic definitions
+  } 
+  while (!successful_exchange);
 
-  // requires free here
-  // free(temp);
+  // TODO: Need to free the node
+
+  return {};
+}
+
+template <typename T>
+bool LocklessQueue<T>::is_empty()
+{
+  return head.load() == 0;
+}
+
+// Queue Implementation
+
+template <typename T>
+Queue<T>::Queue()
+{
+  head = 0;
+}
+
+template <typename T>
+Queue<T>::~Queue()
+{
+  // TODO: Need to free the queue
+}
+
+template <typename T>
+void Queue<T>::enqueue(T item)
+{
+  // TODO: requires malloc here
+}
+
+template <typename T>
+T Queue<T>::dequeue()
+{
+  if (head == 0)
+    return {};
+
+  Node* temp = head;
+  head = head->next;
+  T item = temp->item;
+
+  if (head == 0)
+    tail = 0;
+
+  // TODO: Need to free the node
 
   return item;
 }
 
-int empty(Queue *queue) {
-  return queue->head == 0;
+template <typename T>
+bool Queue<T>::is_empty()
+{
+  return head == 0;
 }


### PR DESCRIPTION
Was previously not implemented as a class. This allows template arguments for the queue to allow for more flexibility. See
#21 for Lockless Queue basics.