### PR TITLE
Move global constructors definition into linker script for clang compatability

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: Google
 DerivePointerAlignment: false
 PointerAlignment: Left
+IndentPPDirectives: BeforeHash 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 kernel/build
 .gdb_history
 qemu_log.log
+kernel_output.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 kernel/build
 .gdb_history
 qemu_log.log
+test.dd
+test.hex
+expectedFS/*
 kernel_output.log

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,13 @@
+{
+  "configurations": [
+    {
+      "name": "Linux",
+      "includePath": ["${workspaceFolder}/kernel/include/**"],
+      "cStandard": "c23",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "linux-gcc-arm64",
+      "configurationProvider": "ms-vscode.makefile-tools"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "files.associations": {
-        "compare": "cpp",
-        "type_traits": "cpp"
-    }
+  "files.associations": {
+    "compare": "cpp",
+    "type_traits": "cpp"
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
-# This is the makefile for the OS in general
-# There are makefiles in the subdirectories for each component
+# This is the makefile for the OS in general.
+# There are makefiles in the subdirectories for each component.
 # Recursive make is considered harmful. Bite me.
 
 COMPONENTS = kernel
 TARGET =
+
 .PHONY: all debug clean qemu $(COMPONENTS)
 
 all: $(COMPONENTS)
 
 components: $(COMPONENTS)
 
+# Invoke make for each component subdir
 $(COMPONENTS):
 	$(MAKE) -C $@ $(TARGET)
 
 debug: TARGET = debug
 debug: components
 
+# Build everything, then invoke qemu
 qemu: components
 	$(MAKE) -C kernel qemu
 
+# Invoke "clean" in each component subdir
 clean:
 	for dir in $(COMPONENTS); do \
 		$(MAKE) -C $$dir clean; \

--- a/createFilesForSDtests.py
+++ b/createFilesForSDtests.py
@@ -1,0 +1,9 @@
+# creates a file filled with 4-byte hex representting its address
+# verify with `xxd -g 4 test.dd > test.hex`
+size_mb = 1
+size_bytes = size_mb * 1024 * 1024
+
+
+with open("test.dd", "wb") as f:
+    for i in range(3, size_bytes, 4):
+        f.write((i % (0x100000000)).to_bytes(4, "little"))

--- a/debug.sh
+++ b/debug.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 GDB_PATH="/u/hill/Coursework/CS378/tools/arm-gnu-toolchain/bin/aarch64-none-elf-gdb"
+
+# Init script is a clean debuggin state
 GDB_SCRIPT="gdb-init-script.gdb"
+
+# This one is for setting predefined breakpoints for ease of debugging
+# GDB_SCRIPT="gdb-debug-script.gdb"
+
 KERNEL_ELF="kernel/build/kernel.elf"
 
 # Kill any running QEMUs

--- a/debug.sh
+++ b/debug.sh
@@ -17,3 +17,9 @@ make clean debug > qemu_log.log 2>&1 &
 
 # Start debugging
 exec "$GDB_PATH" -x "$GDB_SCRIPT" "$KERNEL_ELF"
+
+
+# if you get a nfs error, try running the following command:
+# lsof +D ...{path to your nfs lingering file directory}...
+# find the pid of the process that has it in its Name column (will most likely be a aarch64-n...) 
+# use kill -9 {pid} to kill it

--- a/gdb-debug-script.gdb
+++ b/gdb-debug-script.gdb
@@ -1,0 +1,40 @@
+# NOTE: This is a custom script that sets 3 breakpoints.
+# 1st breakpoint: beginning of kernelMain()
+# 2nd breakpoint: what you want to debug (e.g., HashMap constructor in this case)
+# 3rd breakpoint: typing 'continue' into GDB will continue to this point (if it doesn't hang)
+
+# USAGE: Plug this script into 'GDB_SCRIPT' inside debug.sh or whatever other debug script.
+# Set your 2nd breakpoint to after whatever location that is hanging. If it hangs,
+# the 'echo' will never execute, and now you can examine the state of the system.
+
+# Connect to QEMU
+target remote :1234
+
+# Load symbols
+add-symbol-file kernel/build/kernel.elf 0x80000
+
+# Kill QEMU on GDB exit
+define hook-quit
+  shell pkill -f qemu-system-aarch64
+end
+
+# Set a breakpoint at kernelMain
+b kernelMain
+
+# Set a breakpoint at the HashMap constructor
+b "HashMap<int, int, DefaultIntegerHash>::HashMap(int, double, DefaultIntegerHash const&)"
+
+# Set a breakpoint after all HashMap tests are done
+b hashmapTests.h:34
+
+# Define commands for the HashMap constructor breakpoint:
+#  - "silent" means don't print normal GDB messages
+#  - print a helpful message, then continue again
+commands 2
+  silent
+  echo "\n[DEBUG] >>> Hit HashMap constructor => not stuck in 'new' or 'malloc'.\n"
+  continue
+end
+
+# After loading, immediately continue from kernelMain
+continue

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,93 +1,132 @@
-# Citations in Makefile
+# Citations
 # https://makefiletutorial.com/
 # https://wiki.osdev.org/Raspberry_Pi_Bare_Bones
+
 # Info on implicit rules and naming conventions:
-# https://www.gnu.org/software/make/manual/make.html#Implicit-Rules Info
+# https://www.gnu.org/software/make/manual/make.html#Implicit-Rules
 
 # Programs
 ARMBIN := /u/gheith/public/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin
 QEMUBIN := /u/hill/Coursework/CS378/tools/qemu/bin
 QEMU_LIBS := /u/hill/Coursework/CS378/tools/glib/lib/x86_64-linux-gnu
-AS := $(ARMBIN)/aarch64-none-linux-gnu-as # Assembler
-CC := $(ARMBIN)/aarch64-none-linux-gnu-gcc # C Compiler
-CXX := $(ARMBIN)/aarch64-none-linux-gnu-g++ # C++ Compiler
-OBJCOPY := $(ARMBIN)/aarch64-none-linux-gnu-objcopy # Objcopy
-GDB := $(ARMBIN)/aarch64-none-linux-gnu-gdb # GDB
-QEMU := $(QEMUBIN)/qemu-system-aarch64
-# Flags and params
+
+AS := $(ARMBIN)/aarch64-none-linux-gnu-as 						# Assembler
+CC := $(ARMBIN)/aarch64-none-linux-gnu-gcc 						# C Compiler
+CXX := $(ARMBIN)/aarch64-none-linux-gnu-g++ 					# C++ Compiler
+OBJCOPY := $(ARMBIN)/aarch64-none-linux-gnu-objcopy 	# Objcopy
+GDB := $(ARMBIN)/aarch64-none-linux-gnu-gdb 					# GDB
+QEMU := $(QEMUBIN)/qemu-system-aarch64 								# QEMU
+
+# QEMU flags and params
 QEMU_FLAGS := -no-reboot -M raspi3b -nographic -smp 4
+
+# Optional kernel output log file
+QEMU_LOG ?=
+ifneq ($(QEMU_LOG),)
+QEMU_FLAGS += -serial file:../$(QEMU_LOG)
+endif
+
 CCFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib
-CXXFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib -mno-outline-atomics -fno-builtin -fno-stack-protector -fno-exceptions -fno-rtti -nodefaultlibs -nostartfiles -DDEBUG_ENABLED=$(DEBUG_ENABLED)
+CXXFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib \
+						-mno-outline-atomics -fno-builtin -fno-stack-protector \
+						-fno-exceptions -fno-rtti -nodefaultlibs -nostartfiles \
+						-DDEBUG_ENABLED=$(DEBUG_ENABLED)
+
+# Enable debug prints
+DEBUG_ENABLED ?= 0
 
 ASFLAGS :=
 DEBUG_FLAGS := -g
 OPT_FLAGS := -O2
-# Desired object files, executables names, etc.
-BUILD = build
-SRCDIR = src
-INCDIR = include
-VPATH = $(SRCDIR) $(INCDIR)
-# NOTE(Nate): The wildcard and the vpath could fuck us up here when used
-# together
-CSRC = $(wildcard $(SRCDIR)/*.c)
-COBJ = $(patsubst $(SRCDIR)/%.c,%.o,$(CSRC))
-CXXSRC = $(wildcard $(SRCDIR)/*.cpp)
-CXXOBJ = $(patsubst $(SRCDIR)/%.cpp,%.o,$(CXXSRC))
-ASSRC = $(wildcard $(SRCDIR)/*.s)
-ASOBJ = $(patsubst $(SRCDIR)/%.s,%.o,$(ASSRC))
-SRCS = $(CSRC) $(CXXSRC) $(ASSRC)
-OBJS = $(addprefix $(BUILD)/, $(COBJ) $(CXXOBJ) $(ASOBJ))
-EXEC = $(BUILD)/kernel.elf
-IMG = $(BUILD)/kernel8.img
-TMP_IMG = $(BUILD)/kernel8_tmp.img
-# Flags
-DEBUG_ENABLED ?= 0
 
+# For generating dependency files automatically
+DEPFLAGS = -MMD -MP
+
+# Desired directories, object files, executables names, etc.
+BUILD 	:= build
+SRCDIR 	:= src
+INCDIR 	:= include
+
+# Dynamically find all subdirectories under include/
+INC_SUBDIRS := $(shell find $(INCDIR) -type d)
+
+# For each subdir in include/, add "-I subdir" to the compiler flags
+INC_PATHS := $(foreach d, $(INC_SUBDIRS), -I $d)
+CCFLAGS   += $(INC_PATHS)
+CXXFLAGS  += $(INC_PATHS)
+
+# Search recursively for all files to build
+CSRC   	:= $(shell find $(SRCDIR) -name '*.c')
+CXXSRC 	:= $(shell find $(SRCDIR) -name '*.cpp')
+ASSRC  	:= $(shell find $(SRCDIR) -name '*.s')
+
+# Produce object lists
+COBJ 		:= $(patsubst $(SRCDIR)/%.c,%.o,$(CSRC))
+CXXOBJ 	:= $(patsubst $(SRCDIR)/%.cpp,%.o,$(CXXSRC))
+ASOBJ 	:= $(patsubst $(SRCDIR)/%.s,%.o,$(ASSRC))
+
+OBJS 		:= $(addprefix $(BUILD)/, $(COBJ) $(CXXOBJ) $(ASOBJ))
+
+# The specialized CRT files must come first/last
+CRTI := $(BUILD)/crti.o
+CRTN := $(BUILD)/crtn.o
+
+# Filter them out of the main OBJ list
+OTHER_OBJS := $(filter-out $(CRTI) $(CRTN), $(OBJS))
+
+EXEC 		:= $(BUILD)/kernel.elf
+IMG 		:= $(BUILD)/kernel8.img
+
+# ------------------------------------------------------------------------
 .PHONY: all clean debug qemu
 
-# Build an operating system
+# Default rule
 all: $(IMG)
 
-# Set the debug flags and compile
+# Debug build
 debug: OPT_FLAGS = -O0
 debug: CCFLAGS += $(DEBUG_FLAGS)
 debug: CXXFLAGS += $(DEBUG_FLAGS)
 debug: ASFLAGS += $(DEBUG_FLAGS)
 debug: $(IMG)
-	@echo "To debug via gdb: type into another terminal"
-	@echo "$(GDB) kernel/build/kernel.elf"
-	@echo "target remote :1234"
+	@echo "To debug via gdb:"
+	@echo "   $(GDB) $(EXEC)"
+	@echo "   (gdb) target remote :1234"
 	LD_LIBRARY_PATH=$(QEMU_LIBS) $(QEMU) $(QEMU_FLAGS) -kernel $(IMG) -s -S
 
+# Run under QEMU
 qemu: $(IMG)
 	LD_LIBRARY_PATH=$(QEMU_LIBS) $(QEMU) $(QEMU_FLAGS) -kernel $(IMG)
 
-# The executable, a .elf file (eg. kernel.elf)
+# How to build the final ELF from all objects + linker script
 $(EXEC): linker.ld $(OBJS)
-	$(CXX) -T $< $(CXXFLAGS) -o $@ $(OBJS)
+	$(CXX) -T $< $(CXXFLAGS) -o $@ $(CRTI) -Wl,--start-group $(OTHER_OBJS) -Wl,--end-group $(CRTN)
 
-# THe image, a .img file (eg. kernel.img)
+# How to produce the .img from the ELF
 $(IMG): $(EXEC)
 	$(OBJCOPY) $< -O binary $@
 
-# NOTE(Nate): Implicit rules are okay... but explicit would be good
+# Rules for building object files from C/C++/Assembly
+# We also generate .d dependency files automatically (-MMD -MP)
+$(BUILD)/%.o : $(SRCDIR)/%.c | $(BUILD)
+	@mkdir -p $(dir $@)
+	$(CC) $(CCFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -c $< -o $@ -MF $(basename $@).d
 
-# Implicit rule for creating object files from c files
-$(BUILD)/%.o : %.c | $(BUILD)
-	$(CC) $(CCFLAGS) $(OPT_FLAGS) -c $< -o $@ -I $(INCDIR)
+$(BUILD)/%.o : $(SRCDIR)/%.cpp | $(BUILD)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -c $< -o $@ -MF $(basename $@).d
 
-# Implicit rule for creating object files from c++ files
-$(BUILD)/%.o : %.cpp | $(BUILD)
-	$(CXX) $(CXXFLAGS) $(OPT_FLAGS) -c $< -o $@ -I $(INCDIR)
-
-# Implicit rule for creating object files from assembly files
-$(BUILD)/%.o : %.s | $(BUILD)
+$(BUILD)/%.o : $(SRCDIR)/%.s | $(BUILD)
+	@mkdir -p $(dir $@)
 	$(AS) $(ASFLAGS) -c $< -o $@
 
-# Make the build directory if doesn't exist
+# Create the build directory if needed
 $(BUILD):
-	mkdir $@
+	mkdir -p $@
 
-# All files are in the build dir
+# "make clean" wipes out build/
 clean:
-	$(RM) -rf $(BUILD)
+	rm -rf $(BUILD)
+
+# Pull in automatically generated dependencies, if any
+-include $(OBJS:.o=.d)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -70,10 +70,9 @@ OBJS 		:= $(addprefix $(BUILD)/, $(COBJ) $(CXXOBJ) $(ASOBJ))
 
 # The specialized CRT files must come first/last
 CRTI := $(BUILD)/crti.o
-CRTN := $(BUILD)/crtn.o
 
 # Filter them out of the main OBJ list
-OTHER_OBJS := $(filter-out $(CRTI) $(CRTN), $(OBJS))
+OTHER_OBJS := $(filter-out $(CRTI), $(OBJS))
 
 EXEC 		:= $(BUILD)/kernel.elf
 IMG 		:= $(BUILD)/kernel8.img
@@ -102,7 +101,7 @@ qemu: $(IMG)
 
 # How to build the final ELF from all objects + linker script
 $(EXEC): linker.ld $(OBJS)
-	$(CXX) -T $< $(CXXFLAGS) -o $@ $(CRTI) -Wl,--start-group $(OTHER_OBJS) -Wl,--end-group $(CRTN)
+	$(CXX) -T $< $(CXXFLAGS) -o $@ $(CRTI) -Wl,--start-group $(OTHER_OBJS)
 
 # How to produce the .img from the ELF
 $(IMG): $(EXEC)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -18,7 +18,8 @@ GDB := $(ARMBIN)/aarch64-none-linux-gnu-gdb 					# GDB
 QEMU := $(QEMUBIN)/qemu-system-aarch64 								# QEMU
 
 # QEMU flags and params
-QEMU_FLAGS := -no-reboot -M raspi3b -nographic -smp 4
+QEMU_FLAGS := -no-reboot -M raspi3b -nographic -smp 4 -drive file=../test.dd,if=sd,format=raw -cpu cortex-a72 -m 1G \
+	# --trace "sd*" 
 
 # Optional kernel output log file
 QEMU_LOG ?=
@@ -88,6 +89,7 @@ debug: OPT_FLAGS = -O0
 debug: CCFLAGS += $(DEBUG_FLAGS)
 debug: CXXFLAGS += $(DEBUG_FLAGS)
 debug: ASFLAGS += $(DEBUG_FLAGS)
+debug: DEBUG_ENABLED = 1
 debug: $(IMG)
 	@echo "To debug via gdb:"
 	@echo "   $(GDB) $(EXEC)"

--- a/kernel/include/gpio.h
+++ b/kernel/include/gpio.h
@@ -1,9 +1,14 @@
-// Citation
-// https://cs140e.sergio.bz/docs/BCM2837-ARM-Peripherals.pdf
-
 #include "definitions.h"
+#include "printf.h"
 #include "stdint.h"
 
+/**
+ * @brief Interface for GPIO
+ *
+ * Citations:
+ * + https://cs140e.sergio.bz/docs/BCM2837-ARM-Peripherals.pdf
+ *
+ */
 class GPIO {
  public:
   /**
@@ -13,31 +18,31 @@ class GPIO {
    * 01 = Enable Pull Down control
    * 10 = Enable Pull Up control
    * 11 = Reserved
-   *
    */
   enum PUD { OFF = 0b00, PULL_DOWN = 0b01, PULL_UP = 0b10, RESERVED = 0b11 };
 
-  static constexpr uint64_t gpio_base_address = GPIO_BASE;
+  static constexpr uint32_t gpio_base_address = GPIO_BASE;
 
-  static constexpr uint64_t GPPUD_offset = 0x94;
-  static constexpr uint64_t GPPUDCLK0_offset = 0x98;
-  static constexpr uint64_t GPPUDCLK1_offset = 0x9c;
-
+  static constexpr uint32_t GPFSEL4 = gpio_base_address + 0x10;
+  static constexpr uint32_t GPFSEL5 = gpio_base_address + 0x14;
+  static constexpr uint32_t GPHEN0 = gpio_base_address + 0x64;
+  static constexpr uint32_t GPHEN1 = gpio_base_address + 0x68;
+  static constexpr uint32_t GPLEN0 = gpio_base_address + 0x70;
+  static constexpr uint32_t GPLEN1 = gpio_base_address + 0x74;
+  static constexpr uint32_t GPPUD = gpio_base_address + 0x94;
+  static constexpr uint32_t GPPUDCLK0 = gpio_base_address + 0x98;
+  static constexpr uint32_t GPPUDCLK1 = gpio_base_address + 0x9c;
   /**
    * @brief Sets the Pull-up/down Register Value for all GPIO pins
    *
    * @details "The GPIO Pull-up/down Register controls the actuation of the
-internal pull-up/down control line to ALL the GPIO pins. This register must be
-used in conjunction with the 2 GPPUDCLKn registers."
+   * internal pull-up/down control line to ALL the GPIO pins. This register must
+   * be used in conjunction with the 2 GPPUDCLKn registers."
    *
    * @param status  USE PUD Enum! Used to set the pull-up/down register
    *
    */
-  static void set_pull_register(PUD status) {
-    volatile uint32_t* GPPUD_register =
-        (volatile uint32_t*)(gpio_base_address + GPPUD_offset);
-    *GPPUD_register = status;
-  }
+  static void set_pull_register(PUD status);
 
   /**
    * @brief Applies the pull-up/down configuration to specific GPIO pins
@@ -51,15 +56,38 @@ used in conjunction with the 2 GPPUDCLKn registers."
    * @param device_mask   Bitmask of which GPIO pins to apply the pull-up/down
    * setting to
    */
-  static void set_clock(uint8_t clock_num, uint32_t device_mask) {
-    if (clock_num == 0) {
-      volatile uint32_t* GPPUDCLK0_register =
-          (volatile uint32_t*)(gpio_base_address + GPPUDCLK0_offset);
-      *GPPUDCLK0_register = device_mask;
-    } else if (clock_num == 1) {
-      volatile uint32_t* GPPUDCLK1_register =
-          (volatile uint32_t*)(gpio_base_address + GPPUDCLK1_offset);
-      *GPPUDCLK1_register = device_mask;
-    }
-  }
+  static void set_clock(uint8_t clock_num, uint32_t device_mask);
+
+  /**
+   * @brief Applies `and` mask to a location
+   *
+   * @param location    Memory location to apply the mask to
+   * @param mask        Mask to apply to the location
+   */
+  static void maskAnd(uint32_t location, uint32_t mask);
+
+  /**
+   * @brief Applies `or` mask to a location
+   *
+   * @param location   Memory location to apply the mask to
+   * @param mask       Mask to apply to the location
+   */
+  static void maskOr(uint32_t location, uint32_t mask);
+
+  /**
+   * @brief Applies a mask to a location to set the value to 0
+   *
+   * @param location  Memory location to apply the mask to
+   */
+  static void maskZero(uint32_t location);
+
+  /**
+   * @brief Set the Pull object
+   *
+   * @param clockNum    0 or 1 for GPPUDCLK0 (0-31), 1 for GPPUDCLK1(32-53)
+   * @param pullMask    Bitmask of which GPIO pins to apply the pull-up/down
+   * setting to
+   * @param pud         PUD Enum! Used to set the pull-up/down register
+   */
+  static void setPull(uint8_t clockNum, uint32_t pullMask, PUD pud);
 };

--- a/kernel/include/printf.h
+++ b/kernel/include/printf.h
@@ -131,4 +131,7 @@ int fctprintf(void (*out)(char character, void* arg), void* arg,
 
 #define printf(...) Debug::printf_(__VA_ARGS__)
 
+// TODO: decide on when to have error_printf and what to do with it
+#define error_printf(...) Debug::printf_(__VA_ARGS__)
+
 #endif  // _PRINTF_H_

--- a/kernel/include/queue.h
+++ b/kernel/include/queue.h
@@ -63,7 +63,7 @@ class LocklessQueue {
       // Empty Queue
       if (prev_head->next == 0) return {};
 
-      // A race condition exists here
+      // TODO: A race condition exists here
       item = prev_head->next->item;
     } while (!__atomic_compare_exchange_n(&head, &prev_head, prev_head->next,
                                           true, __ATOMIC_SEQ_CST,

--- a/kernel/include/sd.h
+++ b/kernel/include/sd.h
@@ -1,0 +1,211 @@
+#ifndef SD_H
+#define SD_H
+
+#include "definitions.h"
+#include "gpio.h"
+
+/**
+ * @brief SD card interface
+ *
+ * Resources:
+ *  +
+ * https://github.com/bztsrc/raspi3-tutorial/blob/master/15_writesector/sd.c#L160
+ *  + https://chlazza.nfshost.com/sdcardinfo.html
+ *  + https://myembeddedlinux.blogspot.com/2017/03/interfacing-emmc.html
+ *  + Part 1 Physical Layer Simplified Specification Ver9.10
+ *     + Figure 4-13: SD Memory Card State Diagram (data transfer mode)
+ *
+ */
+class SD {
+  // SD response types
+  static constexpr uint32_t SD_APP_CMD_ENABLED = 0x00000020;
+
+  // Interrupt masks
+  static constexpr uint32_t INT_ERROR_MASK = 0x017f3f00;
+  static constexpr uint32_t INT_TIMEOUT_MASK = 0x00110000;
+
+  // Status masks
+  static constexpr uint32_t ERRORS_MASK = 0xfff9c004;
+  static constexpr uint32_t READ_AVAILABLE = 0x00000800;
+  static constexpr uint32_t WRITE_AVAILABLE = 0x00000400;
+  static constexpr uint32_t DATA_BUSY = 0x00000002;
+  static constexpr uint32_t CMD_BUSY = 0x00000001;
+
+  // SCR masks
+  static constexpr uint32_t CCS_MASK = 1 << 30;
+  static constexpr uint32_t SET_BLKCNT_MASK = 1 << 25;
+
+  // OP_COND flags
+  static uint32_t const OP_COND_NOT_SDSC = 1 << 30;
+  static uint32_t const VOLTAGE_WINDOW = 0x1FF << 15;
+  static uint32_t constexpr OP_COND_FULL =
+      OP_COND_NOT_SDSC   // yes for for both types (SDHC and SDXC)
+      | 1 << 28          // yes for SDXC Maximum Performance
+      | 1 << 24          // switch to 1.8V signal voltage
+      | VOLTAGE_WINDOW;  // Voltage window 2.7-3.6V
+
+  // SD emmc registers
+  static volatile uint32_t* const EMMC_BASE;
+  static volatile uint32_t* const EMMC_ARG2;
+  static volatile uint32_t* const EMMC_BLKSIZECNT;
+  static volatile uint32_t* const EMMC_ARG1;
+  static volatile uint32_t* const EMMC_CMDTM;
+  static volatile uint32_t* const EMMC_RESP0;
+  static volatile uint32_t* const EMMC_RESP1;
+  static volatile uint32_t* const EMMC_RESP2;
+  static volatile uint32_t* const EMMC_RESP3;
+  static volatile uint32_t* const EMMC_DATA;
+  static volatile uint32_t* const EMMC_STATUS;
+  static volatile uint32_t* const EMMC_CONTROL0;
+  static volatile uint32_t* const EMMC_CONTROL1;
+  static volatile uint32_t* const EMMC_INTERRUPT;
+  static volatile uint32_t* const EMMC_IRPT_MASK;
+  static volatile uint32_t* const EMMC_IPRT_EN;
+  static volatile uint32_t* const EMMC_CONTROL2;
+  static volatile uint32_t* const EMMC_FORCE_IRPT;
+  static volatile uint32_t* const EMMC_BOOT_TIMEOUT;
+  static volatile uint32_t* const EMMC_DBG_SEL;
+  static volatile uint32_t* const EMMC_EXRDFIFIO_CFG;
+  static volatile uint32_t* const EMMC_EXRDFIFO_EN;
+  static volatile uint32_t* const EMMC_TUNE_STEP;
+  static volatile uint32_t* const EMMC_TUNE_STEP_STD;
+  static volatile uint32_t* const EMMC_TUNE_STEP_DDR;
+  static volatile uint32_t* const EMMC_INT_SPI;
+  static volatile uint32_t* const EMMC_SLOTISR_VER;
+
+  // Etc
+  static constexpr uint32_t singleMultiDiff = 0x01000022;
+  static constexpr uint32_t readWriteDiff = 0x006FFFFF0;
+
+  /**
+   * @brief Sets the block size and count for reading or writing
+   *
+   * @param startBlock  First block to start reading or writing from
+   * @param count       Number of blocks to read or write
+   * @param isRead      True if reading, false if writing
+   * @return uint32_t   SUCCESS if successful, ERROR otherwise
+   */
+  static uint32_t setBlockSizeCount(uint32_t startBlock, uint32_t count,
+                                    bool isRead);
+
+ public:
+  enum RESPONSE {
+    ERROR = -2,
+    TIMEOUT = -1,
+    FAIL = 0,
+    SUCCESS = 1,
+  };
+
+  enum CMDS {
+    GO_IDLE = 0x00000000,        // go idle state
+    ALL_SEND_CID = 0x02010000,   // ask all cards to send card identification
+    SEND_REL_ADDR = 0x03020000,  // send relative address
+    CARD_SELECT = 0x07030000,    // select/deselect card
+    SEND_IF_COND = 0x08020000,   // send interface condition
+    STOP_TRANS = 0x0C030000,     // stop transmission
+    READ_SINGLE_BLOCK = 0x11220010,    // CMD17: read single block
+    READ_MULTIPLE_BLOCK = 0x12220032,  // CMD18: read multiple blocks
+    SET_BLOCK_COUNT = 0x17020000,      // CMD23: set block count
+    WRITE_SINGLE = 0x18220000,         // write single block
+    WRITE_MULTI = 0x19220022,          // write multiple blocks
+    APP_CMD = 0x37000000,              // application specific command
+    APP_CMD_RCA =
+        0x37010000,  // application specific command with relative card address
+    SET_BUS_WIDTH = 0x06020000,  // set bus width
+    SEND_OP_COND = 0x29020000,   // ACMD41: send operation condition
+    SEND_SCR = 0x33220010        // send SD Card Configuration Register
+  };
+
+  static const uint32_t BLOCKSIZE = 512;
+
+  // SD card static information
+  static bool ccs;
+  static bool canSetBlockCount;
+  static uint32_t SLOTISR_VER;
+  static uint32_t SLOT_STATUS;
+  static uint32_t SDVERSION;
+
+  // SD card configuration registers
+  static uint64_t cardConfigRegister1;
+  static uint64_t cardConfigRegister2;
+  static uint32_t relativeCardAddress;
+
+  // For passing debugging information
+  static uint32_t errInfo;
+
+  /**
+   * @brief Waits for an interrupt to be set for the given mask or a
+   * timeout/error
+   *
+   * @param mask              mask of the interrupt to wait for
+   * @param timeout           number of times to check before timing out
+   * @return SD::RESPONSE     result of the wait
+   */
+  static SD::RESPONSE waitInterrupt(uint32_t mask, uint32_t timeout = 1000000);
+
+  /**
+   * @brief Waits for the status register to have 0s in the bits specified by
+   * mask
+   *
+   * @param mask              what bits to wait for 0 from status register
+   * @param timeout           number of times to check before timing out
+   * @return SD::RESPONSE     result of the wait
+   */
+  static SD::RESPONSE waitStatus(uint32_t mask, uint32_t timeout = 1000000);
+
+  /**
+   * @brief Sends a command to the SD card
+   * Note! RELATIVE_CARD_ADDRESS doesnt not return normaly. the rca is returned
+   * in the response and the error info is returned in the errInfo variable with
+   * the bits in the correct place
+   *
+   * @param cmd               command to send
+   * @param arg               arguments to send with the command
+   * @return SD::RESPONSE     result of the command
+   */
+  static uint32_t sendCommand(SD::CMDS cmd, uint32_t arg);
+
+  /**
+   * @brief Set the clock frequency for the SD card
+   *
+   * @param freq          frequency to set the clock to
+   * @return SD::RESPONSE result of the command
+   */
+  static SD::RESPONSE setClock(uint32_t freq);
+
+  /**
+   * @brief Initialize the eMMC card part of the SD card
+   *
+   */
+  static void eMMCinit();
+
+  /**
+   * @brief Initialize the SD card
+   *
+   * @return uint32_t   result of the initialization (matches with RESPONSE
+   * enum)
+   */
+  static uint32_t init();
+
+  /**
+   * @brief Read from the SD card
+   *
+   * @param startBlock    block to start reading from
+   * @param count         number of blocks to read
+   * @param buffer        buffer to read the data into
+   * @return uint32_t     number of bytes read
+   */
+  static uint32_t read(uint32_t startBlock, uint32_t count, uint8_t* buffer);
+
+  /**
+   * @brief Write to the SD card
+   *
+   * @param startBlock    block to start writing to
+   * @param count         number of blocks to write
+   * @param buffer        buffer to write to the SD card
+   * @return uint32_t     number of bytes written
+   */
+  static uint32_t write(uint32_t startBlock, uint32_t count, uint8_t* buffer);
+};
+
+#endif

--- a/kernel/include/sdTests.h
+++ b/kernel/include/sdTests.h
@@ -1,0 +1,149 @@
+#ifndef SD_TESTS_H
+#define SD_TESTS_H
+
+#include "printf.h"
+#include "sd.h"
+#include "testFramework.h"
+
+// just for debugging to print the whole buffer to compare with the expected
+void printBuffer(uint8_t* buffer, uint32_t size, uint32_t width) {
+  for (uint32_t i = 0; i < size; i++) {
+    if (i % SD::BLOCKSIZE == 0) {
+      debug_printf("Block\n");
+    }
+    debug_printf("%02x", buffer[i]);
+    // only add a space if end of a 8byte chunk
+    if ((i + 1) % 4 == 0) {
+      debug_printf(" ");
+    }
+    if ((i + 1) % (width * 4) == 0) {
+      debug_printf("\n");
+    }
+  }
+}
+
+// compares the buffer by bytes and prints the first index where they differ
+bool compareBuffers(uint8_t* expectedBuffer, uint8_t* readBuffer,
+                    uint32_t size) {
+  for (uint32_t i = 0; i < size; i++) {
+    if (expectedBuffer[i] != readBuffer[i]) {
+      debug_printf("↓↓↓Buffers do not match at index %u: 0x%02x != 0x%02x\n", i,
+                   expectedBuffer[i], readBuffer[i]);
+      return false;
+    }
+  }
+  return true;
+}
+
+// clears the buffer by setting all bytes to 0
+void clearBuffer(uint8_t* buffer, uint32_t size) {
+  for (uint32_t i = 0; i < size; i++) {
+    buffer[i] = 0;
+  }
+}
+
+void sdTests() {
+  // setup
+  initTests("SD Tests");
+
+  uint32_t startBlock, startAddress, blocks, res = SD::SUCCESS, width = 4,
+                                             compareRes;
+  uint8_t* readBuffer;
+  uint8_t* expectedBuffer;
+
+  // Test 1: Read from inital disk (3 blocks)
+  startBlock = 0;
+  startAddress = startBlock * SD::BLOCKSIZE;
+  blocks = 3;
+  readBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  // create an expected buffer that when read in uint32_t litte endian will be
+  // 3, 7, 11, ...
+  expectedBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  for (uint32_t i = 0; i < blocks * SD::BLOCKSIZE; i += 4) {
+    *(uint32_t*)(expectedBuffer + i) = i + 3 + startAddress;
+  }
+
+  res = SD::read(startBlock, blocks, readBuffer);
+  compareRes =
+      compareBuffers(expectedBuffer, readBuffer, blocks * SD::BLOCKSIZE);
+  testsResult("Read from inital disk (3 blocks)",
+              res == blocks * SD::BLOCKSIZE && compareRes);
+  // delete[] readBuffer; // TODO: once delete[] works again
+  // delete[] expectedBuffer; // TODO: once delete[] works again
+
+  // Test 2: Read from inital disk (1 block)
+  startBlock = 3;
+  startAddress = startBlock * SD::BLOCKSIZE;
+  blocks = 1;
+  readBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  expectedBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  for (uint32_t i = 0; i < blocks * SD::BLOCKSIZE; i += 4) {
+    *(uint32_t*)(expectedBuffer + i) = i + 3 + startAddress;
+  }
+
+  res = SD::read(startBlock, blocks, readBuffer);
+  compareRes =
+      compareBuffers(expectedBuffer, readBuffer, blocks * SD::BLOCKSIZE);
+  testsResult("Read from inital disk (1 block)",
+              res == blocks * SD::BLOCKSIZE && compareRes);
+
+  // delete[] readBuffer; // TODO: once delete[] works again
+  // delete[] expectedBuffer; // TODO: once delete[] works again
+
+  // Test 3: Write 3 and read back
+  startBlock = 20;
+  startAddress = startBlock * SD::BLOCKSIZE;
+  blocks = 3;
+  readBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  // creating a buffer that when read in uint8_t will be 0, 1, 2, ... 255, 0, 1,
+  // ...
+  expectedBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  for (int i = 0; i < blocks * SD::BLOCKSIZE; i++) {
+    expectedBuffer[i] = (i + startAddress) % 0x100;
+  }
+  // delete[] readBuffer; // TODO: once delete[] works again
+  // delete[] expectedBuffer; // TODO: once delete[] works again
+
+  // writing the buffer to the disk
+  res = SD::write(startBlock, blocks, expectedBuffer);
+
+  // Read back the actually written blocks
+  res = SD::read(startBlock, blocks, readBuffer);
+  compareRes =
+      compareBuffers(expectedBuffer, readBuffer, blocks * SD::BLOCKSIZE);
+  testsResult("Write 3 and read back",
+              res == blocks * SD::BLOCKSIZE && compareRes);
+  clearBuffer(readBuffer, blocks * SD::BLOCKSIZE);
+
+  // Test 4: Write 1 and read back
+  startBlock = 25;
+  startAddress = startBlock * SD::BLOCKSIZE;
+  blocks = 1;
+  readBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  // creating a buffer that when read in uint8_t will be 0, 0, 2, ... 255, 0, 0,
+  // 2, 0 , 4 ...
+  expectedBuffer = new uint8_t[blocks * SD::BLOCKSIZE];
+  for (int i = 0; i < blocks * SD::BLOCKSIZE; i++) {
+    if ((i + startAddress) % 2 == 1) {
+      expectedBuffer[i] = 0;
+    } else {
+      expectedBuffer[i] = (i + startAddress) % 0x100;
+    }
+  }
+
+  // writing the buffer to the disk
+  res = SD::write(startBlock, blocks, expectedBuffer);
+
+  // Read back the actually written blocks
+  res = SD::read(startBlock, blocks, readBuffer);
+  compareRes =
+      compareBuffers(expectedBuffer, readBuffer, blocks * SD::BLOCKSIZE);
+  testsResult("Write 1 and read back",
+              res == blocks * SD::BLOCKSIZE && compareRes);
+  clearBuffer(readBuffer, blocks * SD::BLOCKSIZE);
+
+  // delete[] readBuffer; // TODO: once delete[] works again
+  // delete[] expectedBuffer; // TODO: once delete[] works again
+}
+
+#endif

--- a/kernel/include/testFramework.h
+++ b/kernel/include/testFramework.h
@@ -9,14 +9,14 @@ void initTests(const char* testSuiteName) {
   testsName = testSuiteName;
   count = 1;
 
-  debug_printf("Starting %s\n", testsName);
+  printf("Starting %s\n", testsName);
 }
 
 void testsResult(const char* testName, bool success) {
   if (success) {
-    debug_printf(" %s %d Passed: %s\n", testsName, count, testName);
+    printf(" %s %d Passed: %s\n", testsName, count, testName);
   } else {
-    debug_printf(" ***%s %d Failed: %s\n", testsName, count, testName);
+    printf(" ***%s %d Failed: %s\n", testsName, count, testName);
   }
   count++;
 }

--- a/kernel/include/tester.h
+++ b/kernel/include/tester.h
@@ -4,9 +4,12 @@
 #include "cores.h"
 #include "eventTests.h"
 #include "heapTests.h"
+#include "sdTests.h"
 
 void runTests() {
   eventLoopTests();
+
+  sdTests();
   // Must be done last until free is implemented
   heapTests();
 }

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -15,18 +15,20 @@ SECTIONS
 
     .init_array :
     {
-        crti.o(.init_array)
-        KEEP (*(SORT(EXCLUDE_FILE(crti.o crtn.o) .init_array.*)))
-        KEEP (*(EXCLUDE_FILE(crti.o crtn.o) .init_array))
-        crtn.o(.init_array)
+        . = ALIGN(8);
+        _init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        _init_array_end = .;
     } > ram
 
     .fini_array :
     {
-        crti.o(.fini_array)
-        KEEP (*(SORT(EXCLUDE_FILE(crti.o crtn.o) .fini_array.*)))
-        KEEP (*(EXCLUDE_FILE(crti.o crtn.o) .fini_array))
-        crtn.o(.fini_array)
+        . = ALIGN(8);
+        _fini_array_start = .;
+        KEEP (*(SORT(.fini_array.*)))
+        KEEP (*(.fini_array))
+        _fini_array_end = .;
     } > ram
 
     .rodata :

--- a/kernel/src/crti.cpp
+++ b/kernel/src/crti.cpp
@@ -1,4 +1,4 @@
-// Global Constructors from
+// Global Constructors, modified from
 // https://wiki.osdev.org/Calling_Global_Constructors (Public Domain)
 
 typedef void (*func_ptr)(void);
@@ -9,18 +9,15 @@ extern func_ptr _fini_array_start[0], _fini_array_end[0];
 namespace CRTI {
 
 void _init(void) {
-  for (func_ptr* func = _init_array_start; func != _init_array_end; func++)
-    (*func)();
+  for (func_ptr* func = _init_array_start; func != _init_array_end; func++) {
+    if (*func != nullptr) (*func)();
+  }
 }
 
 void _fini(void) {
-  for (func_ptr* func = _fini_array_start; func != _fini_array_end; func++)
-    (*func)();
+  for (func_ptr* func = _fini_array_start; func != _fini_array_end; func++) {
+    if (*func != nullptr) (*func)();
+  }
 }
 
 };  // namespace CRTI
-
-func_ptr _init_array_start[0] __attribute__((used, section(".init_array"),
-                                             aligned(sizeof(func_ptr)))) = {};
-func_ptr _fini_array_start[0] __attribute__((used, section(".fini_array"),
-                                             aligned(sizeof(func_ptr)))) = {};

--- a/kernel/src/crtn.cpp
+++ b/kernel/src/crtn.cpp
@@ -1,9 +1,0 @@
-// Global Constructors from
-// https://wiki.osdev.org/Calling_Global_Constructors (Public Domain)
-
-typedef void (*func_ptr)();
-
-func_ptr _init_array_end[0] __attribute__((used, section(".init_array"),
-                                           aligned(sizeof(func_ptr)))) = {};
-func_ptr _fini_array_end[0] __attribute__((used, section(".fini_array"),
-                                           aligned(sizeof(func_ptr)))) = {};

--- a/kernel/src/gpio.cpp
+++ b/kernel/src/gpio.cpp
@@ -1,0 +1,39 @@
+#include "gpio.h"
+
+void GPIO::set_pull_register(PUD status) {
+  volatile uint32_t* GPPUD_register = (volatile uint32_t*)(GPPUD);
+  *GPPUD_register = status;
+}
+
+void GPIO::set_clock(uint8_t clock_num, uint32_t device_mask) {
+  volatile uint32_t* GPPUDCLK_register =
+      (volatile uint32_t*)(GPPUDCLK0) + clock_num;
+  *GPPUDCLK_register = device_mask;
+}
+
+void GPIO::maskAnd(uint32_t location, uint32_t mask) {
+  volatile uint32_t* locationPTR = (volatile uint32_t*)location;
+  uint32_t temp = *locationPTR;
+  *locationPTR &= mask;
+}
+
+void GPIO::maskOr(uint32_t location, uint32_t mask) {
+  volatile uint32_t* locationPTR = (volatile uint32_t*)location;
+  uint32_t temp = *locationPTR;
+  *locationPTR |= mask;
+}
+
+void GPIO::maskZero(uint32_t location) {
+  volatile uint32_t* locationPTR = (volatile uint32_t*)location;
+  *locationPTR = 0;
+}
+
+void GPIO::setPull(uint8_t clockNum, uint32_t pullMask, PUD pud) {
+  set_pull_register(pud);
+  // wait(150); // wait 150 cycles becuase we are supposed
+  set_clock(clockNum, pullMask);
+
+  // reset the registers back to normal
+  set_pull_register(PUD::OFF);
+  set_clock(1, 0);
+}

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -7,9 +7,11 @@
 #include "crti.h"
 #include "event_loop.h"
 #include "heap.h"
+#include "interrupts.h"
 #include "machine.h"
 #include "physmem.h"
 #include "printf.h"
+#include "sd.h"
 #include "stdint.h"
 #include "system_timer.h"
 #include "tester.h"
@@ -29,20 +31,9 @@ extern "C" void kernelMain() {
 
   SMP::bootCores();
 
+  SD::init();
+
   setupTests();
-
-  SystemTimer::setup_timer(0);
-  schedule_event([=]() {
-    uint64_t last_time = current_time;
-    while (true) {
-      if (last_time != current_time) {
-        debug_printf("Heartbeat: %u\n", current_time);
-        last_time = current_time;
-      }
-    }
-  });
-
-  run_page_tests();
 
   event_loop();
 

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -3,21 +3,16 @@
 
 #include "kernel.h"
 
-#include "atomics.h"
 #include "cores.h"
 #include "crti.h"
-#include "definitions.h"
 #include "event_loop.h"
 #include "heap.h"
-#include "interrupts.h"
-#include "crti.h"
-#include "physmem.h"
 #include "machine.h"
+#include "physmem.h"
 #include "printf.h"
 #include "stdint.h"
 #include "system_timer.h"
 #include "tester.h"
-#include "uart.h"
 
 extern "C" void kernelMain() {
   // Handled uart Init
@@ -51,5 +46,6 @@ extern "C" void kernelMain() {
 
   event_loop();
 
-  while (1);
+  while (1)
+    ;
 }

--- a/kernel/src/sd.cpp
+++ b/kernel/src/sd.cpp
@@ -1,0 +1,686 @@
+
+#include "sd.h"
+
+// SD emmc registers
+volatile uint32_t* const SD::EMMC_BASE =
+    (volatile uint32_t*)0x3F300000;  // 0x3F300000 + 0x00
+volatile uint32_t* const SD::EMMC_ARG2 =
+    (volatile uint32_t*)0x3F300000;  // 0x3F300000 + 0x00
+volatile uint32_t* const SD::EMMC_BLKSIZECNT =
+    (volatile uint32_t*)0x3F300004;  // 0x3F300000 + 0x04
+volatile uint32_t* const SD::EMMC_ARG1 =
+    (volatile uint32_t*)0x3F300008;  // 0x3F300000 + 0x08
+volatile uint32_t* const SD::EMMC_CMDTM =
+    (volatile uint32_t*)0x3F30000C;  // 0x3F300000 + 0x0C
+volatile uint32_t* const SD::EMMC_RESP0 =
+    (volatile uint32_t*)0x3F300010;  // 0x3F300000 + 0x10
+volatile uint32_t* const SD::EMMC_RESP1 =
+    (volatile uint32_t*)0x3F300014;  // 0x3F300000 + 0x14
+volatile uint32_t* const SD::EMMC_RESP2 =
+    (volatile uint32_t*)0x3F300018;  // 0x3F300000 + 0x18
+volatile uint32_t* const SD::EMMC_RESP3 =
+    (volatile uint32_t*)0x3F30001C;  // 0x3F300000 + 0x1C
+volatile uint32_t* const SD::EMMC_DATA =
+    (volatile uint32_t*)0x3F300020;  // 0x3F300000 + 0x20
+volatile uint32_t* const SD::EMMC_STATUS =
+    (volatile uint32_t*)0x3F300024;  // 0x3F300000 + 0x24
+volatile uint32_t* const SD::EMMC_CONTROL0 =
+    (volatile uint32_t*)0x3F300028;  // 0x3F300000 + 0x28
+volatile uint32_t* const SD::EMMC_CONTROL1 =
+    (volatile uint32_t*)0x3F30002C;  // 0x3F300000 + 0x2C
+volatile uint32_t* const SD::EMMC_INTERRUPT =
+    (volatile uint32_t*)0x3F300030;  // 0x3F300000 + 0x30
+volatile uint32_t* const SD::EMMC_IRPT_MASK =
+    (volatile uint32_t*)0x3F300034;  // 0x3F300000 + 0x34
+volatile uint32_t* const SD::EMMC_IPRT_EN =
+    (volatile uint32_t*)0x3F300038;  // 0x3F300000 + 0x38
+volatile uint32_t* const SD::EMMC_CONTROL2 =
+    (volatile uint32_t*)0x3F30003C;  // 0x3F300000 + 0x3c
+volatile uint32_t* const SD::EMMC_FORCE_IRPT =
+    (volatile uint32_t*)0x3F300050;  // 0x3F300000 + 0x50
+volatile uint32_t* const SD::EMMC_BOOT_TIMEOUT =
+    (volatile uint32_t*)0x3F300070;  // 0x3F300000 + 0x70
+volatile uint32_t* const SD::EMMC_DBG_SEL =
+    (volatile uint32_t*)0x3F300074;  // 0x3F300000 + 0x74
+volatile uint32_t* const SD::EMMC_EXRDFIFIO_CFG =
+    (volatile uint32_t*)0x3F300080;  // 0x3F300000 + 0x80
+volatile uint32_t* const SD::EMMC_EXRDFIFO_EN =
+    (volatile uint32_t*)0x3F300084;  // 0x3F300000 + 0x84
+volatile uint32_t* const SD::EMMC_TUNE_STEP =
+    (volatile uint32_t*)0x3F300088;  // 0x3F300000 + 0x88
+volatile uint32_t* const SD::EMMC_TUNE_STEP_STD =
+    (volatile uint32_t*)0x3F30008C;  // 0x3F300000 + 0x8C
+volatile uint32_t* const SD::EMMC_TUNE_STEP_DDR =
+    (volatile uint32_t*)0x3F300090;  // 0x3F300000 + 0x90
+volatile uint32_t* const SD::EMMC_INT_SPI =
+    (volatile uint32_t*)0x3F3000F0;  // 0x3F300000 + 0xF0
+volatile uint32_t* const SD::EMMC_SLOTISR_VER =
+    (volatile uint32_t*)0x3F3000FC;  // 0x3F300000 + 0xFC
+
+// Initializing static variables
+uint32_t SD::SLOTISR_VER = 0;
+uint32_t SD::SLOT_STATUS = 0;
+uint32_t SD::SDVERSION = 0;
+uint64_t SD::cardConfigRegister1 = 0;
+uint64_t SD::cardConfigRegister2 = 0;
+uint32_t SD::relativeCardAddress = 0;
+uint32_t SD::errInfo = 0;
+bool SD::ccs = 0;
+bool SD::canSetBlockCount = 0;
+
+SD::RESPONSE SD::waitInterrupt(uint32_t mask, uint32_t timeout) {
+  // make sure we are will stop waiting if we get an error
+  mask |= INT_ERROR_MASK;
+  while (!(*EMMC_INTERRUPT & mask) && timeout--) {
+    // wait(100); // TODO: swap to non busy waiting
+  }
+
+  // check if we timed out
+  uint32_t interruptValue = *EMMC_INTERRUPT;
+  if (timeout <= 0 || (interruptValue & INT_TIMEOUT_MASK)) {
+    *EMMC_INTERRUPT = interruptValue;  // sending acknowledgement
+    error_printf(
+        "Error: Timeout waiting for interrupt. EMMC_INTERRUPT=(0x%08x)\n",
+        interruptValue);
+    return TIMEOUT;
+  }
+
+  // check if there was an error
+  if (interruptValue & INT_ERROR_MASK) {
+    *EMMC_INTERRUPT = interruptValue;  // sending acknowledgement
+    error_printf("Error: waiting for interrupt EMMC_INTERRUPT=(0x%08x)\n",
+                 interruptValue);
+    return ERROR;
+  }
+
+  // success!
+  *EMMC_INTERRUPT = interruptValue;  // sending acknowledgement
+  return SUCCESS;
+}
+
+SD::RESPONSE SD::waitStatus(uint32_t mask, uint32_t timeout) {
+  // wait for the status register to have 0s in the bits specified by mask and
+  // no errors
+  while ((*EMMC_STATUS & mask) && !(*EMMC_INTERRUPT & INT_ERROR_MASK) &&
+         timeout--) {
+    // wait(100); // TODO: swap to non busy waiting
+  }
+
+  uint32_t interruptValue = *EMMC_INTERRUPT;
+  // check if we timed out
+  if (timeout <= 0 || (interruptValue & INT_TIMEOUT_MASK)) {
+    error_printf(
+        "Error: Timeout waiting for SD status to be ready "
+        "EMMC_INTERRUPT=(0x%08x)\n",
+        interruptValue);
+    return TIMEOUT;
+  }
+
+  // check if there was an error
+  if (interruptValue & INT_ERROR_MASK) {
+    error_printf(
+        "Error: waiting for SD status to be ready EMMC_INTERRUPT=(0x%08x)\n",
+        interruptValue);
+    return ERROR;
+  }
+  return SUCCESS;
+}
+
+uint32_t SD::sendCommand(CMDS cmd, uint32_t arg) {
+  debug_printf("SD::sendCommand: cmd 0x%08x || arg 0x%08x\n", cmd, arg);
+  uint32_t myResponse = SUCCESS;
+  errInfo = 0;
+  // check if the command is app specific
+  switch (cmd) {
+    case CMDS::SET_BUS_WIDTH:
+    case CMDS::SEND_OP_COND:
+    case CMDS::SEND_SCR:
+      // if we are in relative address mode we need to add flag for that and
+      // include it in args
+      CMDS appCMD = relativeCardAddress ? APP_CMD_RCA : APP_CMD;
+      // if it is app specific then we need to send the app command first
+
+      myResponse = sendCommand(appCMD, relativeCardAddress);
+
+      // check if the app specific command was successful
+      if (relativeCardAddress && myResponse < SUCCESS) {
+        error_printf("ERROR: Failed to send app command\n");
+        errInfo = ERROR;
+        return myResponse;
+      }
+  }
+
+  // now check if any commands are already running
+  if ((myResponse = waitStatus(CMD_BUSY)) != SUCCESS) {
+    error_printf("ERROR: Failed while waiting for EMMC to be free\n");
+    errInfo = TIMEOUT;
+    return myResponse;
+  }
+
+  // now we actually setup and send the command
+  *EMMC_INTERRUPT = *EMMC_INTERRUPT;  // clear interrupts
+  *EMMC_ARG1 = arg;
+  *EMMC_CMDTM = (uint32_t)cmd;
+
+  switch (cmd) {
+    case CMDS::SEND_OP_COND:
+      // wait(1000); // TODO: add a wait
+      break;
+    case CMDS::SEND_IF_COND:
+    case CMDS::APP_CMD:
+      // wait(100); // TODO: add a wait
+      break;
+  }
+
+  // wait for interrupt indicating command is done
+  if ((myResponse = waitInterrupt(0x1)) != SUCCESS) {
+    error_printf("ERROR: failed to send EMMC command (0x%08x)\n", cmd);
+    errInfo = myResponse;
+    return myResponse;
+  }
+
+  uint32_t cmdResponse =
+      *EMMC_RESP0;  // half a real response and half the cards status info from
+                    // before and after the command
+  debug_printf("SD::sendCommand: sd card Response: 0x%08x\n", cmdResponse);
+
+  switch (cmd) {
+    case CMDS::GO_IDLE:
+    case CMDS::APP_CMD:
+      return SUCCESS;
+    case CMDS::APP_CMD_RCA:
+      return cmdResponse & SD_APP_CMD_ENABLED
+                 ? SUCCESS
+                 : FAIL;  // check to make sure that the stuatus indicates that
+                          // the card is ready for application specific commands
+    case CMDS::SEND_OP_COND:
+      return cmdResponse;
+    case CMDS::SEND_IF_COND:
+      return cmdResponse == arg ? SUCCESS : ERROR;
+    case CMDS::ALL_SEND_CID:
+      return *EMMC_RESP3 | *EMMC_RESP2 | *EMMC_RESP1 |
+             cmdResponse;  // TODO: returning the whole response??
+    case CMDS::SEND_REL_ADDR:
+      // response has lower half error info and uppper half RCA
+      errInfo = ((cmdResponse & 0x1FFF) | ((cmdResponse & (1 << 13)) << 6) |
+                 ((cmdResponse & (3 << 14)) << 8)) &
+                ERRORS_MASK;  // lower 13 bits are in normal place and upper
+                              // 3 bits have to be moved to right place 13
+                              // -> 19, 14 ->22, 15 ->23
+      return (cmdResponse & 0xFFFF0000);
+  }
+  return cmdResponse & ERRORS_MASK;
+}
+
+SD::RESPONSE SD::setClock(uint32_t freq) {
+  // first wait for command and data lines to be free "Command line still used
+  // by previous command" bit 0 and "Data lines still used by previous data
+  // transfer" bit 1 to be 0
+  RESPONSE r = waitStatus(0b11);
+  if (r != SUCCESS) {
+    error_printf(
+        "ERROR: Failed waiting for command and data lines to be free\n");
+    return r;
+  }
+
+  // disable "SD clock enable"
+  *EMMC_CONTROL0 &= ~((uint32_t)0b100);
+
+  // finding how much we have to slow down the clock by
+  // finding the log2 of the frequency
+  uint32_t shift, x = 41666666 / freq -
+                      1;  // 41666666 is the base frequency of system clock
+  shift = (x == 0) ? 0 : (31 - __builtin_clz(x));
+  if (shift > 7) shift = 7;
+
+  //  if(hv>HOST_SPEC_V2) d=c; else d=(1<<s); i am guessing this is for if
+  //  the host is above 2 but i think we dont need to worry about?
+  uint32_t divisor = (1 << shift);
+  if (divisor <= 2) {
+    divisor = 2;
+    shift = 0;
+  }
+
+  // if(hv>HOST_SPEC_V2) h=(d&0x300)>>2; // TODO: doesnt matter assusming
+  // version doesnt go above 2 (once this does matter we nee to also change the
+  // next true line of code)
+
+  // moving the divisor into the correct place
+  divisor = (divisor & 0xFF) << 8;
+
+  // putting in our own divisor into "SD clock base divider LSBs" (bits 8-15)
+  // and clearing "SD clock base divider MSBs" (bits 6-7)
+  constexpr uint32_t mask6_15 = 0x3FF << 6;
+  *EMMC_CONTROL1 = *EMMC_CONTROL1 & (~mask6_15) | divisor;
+
+  // renable "SD clock enable"
+  *EMMC_CONTROL1 |= 0b100;
+
+  // wait for the clock to be stable
+  r = waitStatus(DATA_BUSY);
+  if (r != SUCCESS) {
+    error_printf("ERROR: Failed while waiting for the clock to be stable\n");
+    return r;
+  }
+
+  return SUCCESS;
+}
+
+void SD::eMMCinit() {
+  // *** setting up the SD card detect pin (pin47) by masking out its 3
+  // alternate clear out any alternate function selection for pin47
+  GPIO::maskAnd(GPIO::GPFSEL4, ~(7 << (7 * 3)));
+
+  // set pin47 to be pull up
+  GPIO::setPull(1, 1 << 15, GPIO::PUD::PULL_UP);
+
+  // now we need to set that pin to also be high detect
+  GPIO::maskOr(GPIO::GPHEN1, 1 << 15);
+
+  // *** set up pins 48 and 49 for eMMC? supposedly for "GPIO_CLK, GPIO_CMD"
+  // set alt function 3 for 48 and 49
+  GPIO::maskOr(GPIO::GPFSEL4, (3 << (7 * 3)) | (3 << (8 * 3)));
+  // set pull up for 48 and 49
+  GPIO::setPull(1, (1 << 16) | (1 << 17), GPIO::PUD::PULL_UP);
+
+  // *** set up pins 50-53 for eMMC? supposedly for "GPIO_DAT0, GPIO_DAT1,
+  // GPIO_DAT2, GPIO_DAT3" set alt function 3 for 50-53
+
+  GPIO::maskOr(GPIO::GPFSEL5, (3 << (0 * 3)) | (3 << (1 * 3)) | (3 << (2 * 3)) |
+                                  (3 << (3 * 3)));
+  // set pull up for 50-53
+  GPIO::setPull(1, (1 << 18) | (1 << 19) | (1 << 20) | (1 << 21),
+                GPIO::PUD::PULL_UP);
+}
+
+uint32_t SD::init() {
+  uint32_t timeout = 1000000;
+  uint32_t response = SUCCESS;
+  eMMCinit();
+
+  // *** this part starts to make a little more sense. we are now doing very
+  // standard setup for EMMC
+
+  // first get info about the sd card
+  SLOTISR_VER = (*EMMC_SLOTISR_VER);
+  SLOT_STATUS = SLOTISR_VER & 0xFF;        // bits 0-7
+  SDVERSION = (SLOTISR_VER >> 16) & 0xFF;  // bits 16-23
+
+  // resetting the sd card
+  *EMMC_CONTROL0 = 0x00000000;
+  *EMMC_CONTROL1 |= 0x01000000;  // "Reset the complete host circuit"
+
+  timeout = 1000;
+  // wait for the reset to finish
+  while ((*EMMC_CONTROL1 & 0x01000000) && timeout--) {
+    // TODO: add a wait
+  };
+  if (timeout <= 0) {
+    error_printf("Error: Timeout waiting for EMMC host circuit reset\n");
+    return TIMEOUT;
+  }
+  // "Clock enable for internal EMMC clocks for powersaving" at bit 0 and
+  // "Data timeout unit exponent" to 7 at bit 16
+  *EMMC_CONTROL1 = 1 | (7 << 16);
+
+  // setup starting frequency (required to be slow at first for
+  // initialization)
+
+  if ((response = setClock(400000)) != SUCCESS) {
+    error_printf("ERROR:  Unable to set clock frequency to 400000\n");
+    return response;
+  }
+
+  // enable all interrupts
+  *EMMC_IPRT_EN = 0xFFFFFFFF;
+  *EMMC_IRPT_MASK = 0xFFFFFFFF;
+
+  // initalize some variables
+  cardConfigRegister1 = 0;
+  cardConfigRegister2 = 0;
+  relativeCardAddress = 0;
+  errInfo = 0;
+
+  // next step is to send the GO_IDLE command
+  sendCommand(GO_IDLE, 0);
+  if (errInfo) {
+    return ERROR;
+  }
+
+  // send the card its voltage range
+  sendCommand(SEND_IF_COND, 0x000001AA);  // AA is the check pattern and 1 is
+                                          // the voltage range (2.7-3.6V)
+  if (errInfo) {
+    return ERROR;
+  }
+
+  // trying to start the initialization process
+  const uint32_t isCompleteMask = 1 << 31;
+  timeout = 6;
+  while (timeout--) {
+    // wait(400); // TODO: add a wait
+    response = sendCommand(
+        SEND_OP_COND,
+        OP_COND_FULL);  // sending the voltage window for initalization
+
+    if (response & isCompleteMask) {  // check if it is still busy trying to
+                                      // initialize the card
+      break;
+    }
+    debug_printf(
+        "During initialization, card is still busy\n With this response: %x\n",
+        response);
+
+    if (errInfo != TIMEOUT && errInfo != SUCCESS) {
+      error_printf("Error: An error occured during sd initialization\n");
+      return errInfo;
+    }
+  }
+
+  // check if we timed out
+  if (timeout <= 0) {
+    error_printf("Error: Timeout during sd initialization\n");
+    return TIMEOUT;
+  }
+
+  // check if choosing the voltage window was successful
+  if (!(response & VOLTAGE_WINDOW)) {
+    error_printf("Error: Failed to choose voltage window\n");
+    return ERROR;
+  }
+
+  // check for ccs bit
+  uint32_t ccs = response & CCS_MASK;
+
+  // required step
+  sendCommand(ALL_SEND_CID, 0);
+
+  // try to get the relative card address
+  relativeCardAddress = sendCommand(SEND_REL_ADDR, 0);
+  if (errInfo) {
+    error_printf("Error: Failed to get relative card address\n");
+    error_printf("Error response: 0x%x\n", relativeCardAddress);
+    error_printf("Error info: 0x%x\n", errInfo);
+    return ERROR;
+  }
+
+  // setting the clock to the real clock speed
+  if ((response = setClock(25000000)) != SUCCESS) {
+    error_printf("Error: Failed to set clock speed to 25000000\n");
+    return response;
+  }
+
+  // select the card
+  sendCommand(CARD_SELECT, relativeCardAddress);
+  if (errInfo) {
+    error_printf("Error: Failed to select card\n");
+    return ERROR;
+  }
+
+  // wait for no data lines to be in use
+  if (response = waitStatus(DATA_BUSY) != SUCCESS) return response;
+
+  // set the block size
+  *EMMC_BLKSIZECNT = 1 << 16 | BLOCKSIZE;
+
+  // try to get SD to send SCR
+  sendCommand(SEND_SCR, 0);
+  if (errInfo) {
+    error_printf("Error: Failed to send SCR command\n");
+    return ERROR;
+  }
+
+  // wait for interrupt indicating read is ready
+  if ((response = waitInterrupt(0x20)) != SUCCESS) {
+    error_printf("Error: failed to read EMMC\n");
+    return response;
+  }
+
+  // keep trying to get both of the SCR registers
+  timeout = 1000000;
+  response = 0;
+  volatile uint64_t* currentRegister = &cardConfigRegister1;
+  while (timeout--) {
+    // read the data
+    if (*EMMC_STATUS & READ_AVAILABLE) {
+      *currentRegister = *EMMC_DATA;
+      if (currentRegister == &cardConfigRegister2) {
+        // we have set both registers
+        break;
+      }
+      currentRegister = &cardConfigRegister2;
+    } else {
+      // wait(500);
+      debug_printf("Waiting for cardConfigRegisters to be available\n");
+    }
+  }
+  if (timeout <= 0) {
+    error_printf(
+        "Error: Timeout waiting for cardConfigRegisters to be available\n");
+    return TIMEOUT;
+  }
+  // Read the lingering data
+  while (*EMMC_STATUS & READ_AVAILABLE) {
+    uint32_t data = *EMMC_DATA;
+  }
+
+  // check for bus width 4 availability
+  if (cardConfigRegister1 & 1 << 10) {
+    sendCommand(SET_BUS_WIDTH,
+                relativeCardAddress | 0x2);  // try to set the bus width to 4
+                                             // using the relative card address
+    // update contol 0 to enable 4 data lines
+    *EMMC_CONTROL0 |= 0x2;
+  }
+  if (errInfo) {
+    error_printf("Error: Failed to set bus width\n");
+    return ERROR;
+  }
+
+  // check if it supports SET_BLKCNT command
+  canSetBlockCount = cardConfigRegister1 & SET_BLKCNT_MASK;
+  if (canSetBlockCount) {
+    // enable multiple block read
+    printf("SD supports SET_BLKCNT command\n");
+  }
+  if (ccs) {
+    printf("SD is SDHC and SDXC compatiable\n");
+  }
+
+  debug_printf(
+      "SD is initialized with version (%d) and ccs (%d) and slot status (%d)\n",
+      SDVERSION, ccs, SLOT_STATUS);
+  debug_printf("CardConfigRegister1: %064b\n", cardConfigRegister1);
+  debug_printf("CardConfigRegister2: %064b\n", cardConfigRegister2);
+  return SUCCESS;
+}
+
+uint32_t SD::setBlockSizeCount(uint32_t startBlock, uint32_t count,
+                               bool isWrite) {
+  bool isSingleBlock = count == 1;
+  // are we able to read multiple blocks?
+  if (ccs) {
+    // are we able to set the block count?
+    if (isSingleBlock && canSetBlockCount) {
+      sendCommand(SET_BLOCK_COUNT, count);
+      if (errInfo) {
+        error_printf("Error: Failed to set block count\n");
+        return ERROR;
+      }
+    }
+
+    // set the block size and count (count is in bits 16-31 and block size is in
+    // bits 0-15)
+    *EMMC_BLKSIZECNT = (count << 16) | BLOCKSIZE;
+
+    // send the actual command to enable the read/write operation with single or
+    // multiple block
+    sendCommand((CMDS)(READ_SINGLE_BLOCK + (isSingleBlock * singleMultiDiff) +
+                       (isWrite * readWriteDiff)),
+                startBlock);
+    if (errInfo) {
+      error_printf("Error: Failed to read block\n");
+      return ERROR;
+    }
+  } else {
+    // can only read one block at a time
+    // set the block size and count (count is in bits 16-31 and block size is in
+    // bits 0-15)
+    *EMMC_BLKSIZECNT = (1 << 16) | BLOCKSIZE;
+  }
+  return SUCCESS;
+}
+
+uint32_t SD::read(uint32_t startBlock, uint32_t count, uint8_t* buffer) {
+  debug_printf("SD::read current card status: 0x%08x\n", *EMMC_STATUS);
+  uint32_t response = SUCCESS;
+  if (count < 1) count = 1;  // min of 1 block
+
+  // wait for data lines to be free
+  if ((response = waitStatus(DATA_BUSY)) != SUCCESS) {
+    error_printf(
+        "Error: Failed while waiting for EMMC data lines to be free\n");
+    return response;
+  }
+
+  // cast the buffer to a uint32_t pointer for easier reading
+  uint32_t* bufferPtr = (uint32_t*)buffer;
+
+  // update block size and count
+  if ((response = SD::setBlockSizeCount(startBlock, count, false)) != SUCCESS) {
+    error_printf("Error: Failed to set block size and count\n");
+    return response;
+  }
+
+  // try reading all the blocks
+  uint32_t blockOffset = 0;
+
+  if (ccs) {
+    while (blockOffset < count) {
+      // wait for interrupt indicating read is ready
+      if ((response = waitInterrupt(0x20)) != SUCCESS) {
+        error_printf("Error: failed to wait for sd read available\n");
+        return response;
+      }
+
+      // read the data
+      for (uint32_t i = 0; i < BLOCKSIZE / 4; i++) {
+        *bufferPtr++ = *EMMC_DATA;
+      }
+
+      blockOffset++;
+    }
+  } else {
+    while (blockOffset < count) {
+      // if we are not supporting SDHC and SDXC we have to read one block at a
+      // time
+      sendCommand(READ_SINGLE_BLOCK, (startBlock + blockOffset) * BLOCKSIZE);
+      if (errInfo) {
+        error_printf("Error: Failed to enable read block\n");
+        return ERROR;
+      }
+
+      // wait for interrupt indicating read is ready
+      if ((response = waitInterrupt(0x20)) != SUCCESS) {
+        error_printf("Error: failed to wait for sd read available\n");
+        return response;
+      }
+
+      // read the data
+      for (uint32_t i = 0; i < BLOCKSIZE / 4; i++) {
+        *bufferPtr++ = *EMMC_DATA;
+      }
+
+      blockOffset++;
+    }
+  }
+
+  // stop transmission
+  if (count > 1 && ccs && !canSetBlockCount) {
+    sendCommand(STOP_TRANS, 0);
+  }
+
+  // was there an error while reading the blocks
+  if (errInfo) {
+    error_printf("Error: Failed to read blocks. Only read %u blocks\n", count);
+    return errInfo;
+  }
+  return count != blockOffset ? 0 : count * BLOCKSIZE;
+}
+
+uint32_t SD::write(uint32_t startBlock, uint32_t count, uint8_t* buffer) {
+  debug_printf("SD::write current card status: 0x%08x\n", *EMMC_STATUS);
+  uint32_t response = SUCCESS;
+  if (count < 1) count = 1;  // min of 1 block
+
+  // wait for data lines and write to be avaliable
+  if ((response = waitStatus(DATA_BUSY | WRITE_AVAILABLE)) != SUCCESS) {
+    error_printf(
+        "Error: Failed while waiting for data lines to be free and write to be "
+        "avaliable \n");
+    return response;
+  }
+
+  // now we setup the buffer properly
+  uint32_t* bufferPtr = (uint32_t*)buffer;
+
+  // set the block size and count
+  if ((response = SD::setBlockSizeCount(startBlock, count, true)) != SUCCESS) {
+    error_printf("Error: Failed to set block size and count\n");
+    return response;
+  }
+
+  // try reading all the blocks
+  uint32_t blockOffset = 0;
+  if (ccs) {
+    while (blockOffset < count) {
+      // wait for interrupt indicating write is ready
+      if ((response = waitInterrupt(WRITE_AVAILABLE)) != SUCCESS) {
+        error_printf("Error: failed to wait for sd write\n");
+        return response;
+      }
+
+      // write the data
+      for (uint32_t i = 0; i < BLOCKSIZE / 4; i++) {
+        *EMMC_DATA = *bufferPtr++;
+      }
+
+      blockOffset++;
+    }
+  } else {
+    while (blockOffset < count) {
+      // if we are not supporting SDHC and SDXC we have to read one block at a
+      // time
+      sendCommand(WRITE_SINGLE, (startBlock + blockOffset) * BLOCKSIZE);
+      if (errInfo) {
+        error_printf("Error: Failed to enable write block\n");
+        return ERROR;
+      }
+
+      // wait for interrupt indicating write is ready
+      if ((response = waitInterrupt(WRITE_AVAILABLE)) != SUCCESS) {
+        error_printf("Error: failed to wait for sd write\n");
+        return response;
+      }
+
+      // write the data
+      for (uint32_t i = 0; i < BLOCKSIZE / 4; i++) {
+        *EMMC_DATA = *bufferPtr++;
+      }
+
+      blockOffset++;
+    }
+  }
+
+  // stop transmission
+  if (count > 1 && ccs && !canSetBlockCount) {
+    sendCommand(STOP_TRANS, 0);
+  }
+
+  // was there an error?
+  if (errInfo) {
+    error_printf("Error: Failed to write blocks. Only wrote %u blocks\n", count);
+    return errInfo;
+  }
+  return count != blockOffset ? 0 : count * BLOCKSIZE;
+}

--- a/run_until_unexpected.sh
+++ b/run_until_unexpected.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# This script will continuously run 'make qemu' until the last line of
+# kernel output is different than expected.
+
+MAX_SECS=3                      # How many seconds to let QEMU run each time before timing out
+EXPECTED_LINE="HERE 4"          # Change this to the line you expect at the end
+LOGFILE="kernel_output.log"     # File to kernel output
+DEBUG_ENABLED_FLAG=1            # Enable debug prints
+
+COUNTER=0
+
+while true; do
+  # Remove old logs
+  rm -f "$LOGFILE"
+
+  # Make clean
+  make clean
+
+  # Run QEMU for MAX_SECS seconds
+  # Need --foreground otherwise QEMU arguments won't be passed in
+  timeout --foreground ${MAX_SECS}s make DEBUG_ENABLED=$DEBUG_ENABLED_FLAG QEMU_LOG="$LOGFILE" qemu
+
+  # Reset terminal back to cooked mode
+  reset
+
+  COUNTER=$((COUNTER + 1))
+  echo "=============================================="
+  echo "Run #$COUNTER"
+  echo "=============================================="
+
+  # Find the PID of a qemu-system-aarch64 process
+  PID=$(pgrep -f qemu-system-aarch64)
+
+  # Kill the QEMU process running in the background since
+  # timeout doesn't kill everything
+  if [ -n "$PID" ]; then
+    echo "Found QEMU PID: $PID"
+    kill "$PID"
+  else
+    echo "No matching QEMU process found."
+  fi
+
+  # Grab the last line in the kernel output file
+  LAST_LINE="$(tail -n 1 "$LOGFILE")"
+
+  echo "Last line of output: '$LAST_LINE'"
+
+  # If it's not the expected line, something unexpected happened
+  if [ "$LAST_LINE" != "$EXPECTED_LINE" ]; then
+    echo "Unexpected behavior detected in run #$COUNTER!"
+    echo "Exiting..."
+    exit 1
+  fi
+
+  echo "Run #$COUNTER was successful (i.e., ended with '$EXPECTED_LINE'). Retrying..."
+done


### PR DESCRIPTION
For some reason the current `crti`/`crtn` setup doesn't work when compiled using clang, leading it to skip running any constructors.  (`_init_array_start` == `_init_array_end`, despite there being global constructors in the `.init_array` section.)

This PR fixes that by explicitly defining `_init_array_start` and `_init_array_end` in the linker script rather than in individual object files.

Note that I've only tested this with my local compilers, so make sure it still works with your compiler toolchain before merging.