### PR TITLE
Makefile and build system upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 kernel/build
 .gdb_history
 qemu_log.log
+kernel_output.log

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,13 @@
+{
+  "configurations": [
+    {
+      "name": "Linux",
+      "includePath": ["${workspaceFolder}/kernel/include/**"],
+      "cStandard": "c23",
+      "cppStandard": "c++20",
+      "intelliSenseMode": "linux-gcc-arm64",
+      "configurationProvider": "ms-vscode.makefile-tools"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "files.associations": {
-        "compare": "cpp",
-        "type_traits": "cpp"
-    }
+  "files.associations": {
+    "compare": "cpp",
+    "type_traits": "cpp"
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
-# This is the makefile for the OS in general
-# There are makefiles in the subdirectories for each component
+# This is the makefile for the OS in general.
+# There are makefiles in the subdirectories for each component.
 # Recursive make is considered harmful. Bite me.
 
 COMPONENTS = kernel
 TARGET =
+
 .PHONY: all debug clean qemu $(COMPONENTS)
 
 all: $(COMPONENTS)
 
 components: $(COMPONENTS)
 
+# Invoke make for each component subdir
 $(COMPONENTS):
 	$(MAKE) -C $@ $(TARGET)
 
 debug: TARGET = debug
 debug: components
 
+# Build everything, then invoke qemu
 qemu: components
 	$(MAKE) -C kernel qemu
 
+# Invoke "clean" in each component subdir
 clean:
 	for dir in $(COMPONENTS); do \
 		$(MAKE) -C $$dir clean; \

--- a/debug.sh
+++ b/debug.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 GDB_PATH="/u/hill/Coursework/CS378/tools/arm-gnu-toolchain/bin/aarch64-none-elf-gdb"
+
+# Init script is a clean debuggin state
 GDB_SCRIPT="gdb-init-script.gdb"
+
+# This one is for setting predefined breakpoints for ease of debugging
+# GDB_SCRIPT="gdb-debug-script.gdb"
+
 KERNEL_ELF="kernel/build/kernel.elf"
 
 # Kill any running QEMUs

--- a/gdb-debug-script.gdb
+++ b/gdb-debug-script.gdb
@@ -1,0 +1,40 @@
+# NOTE: This is a custom script that sets 3 breakpoints.
+# 1st breakpoint: beginning of kernelMain()
+# 2nd breakpoint: what you want to debug (e.g., HashMap constructor in this case)
+# 3rd breakpoint: typing 'continue' into GDB will continue to this point (if it doesn't hang)
+
+# USAGE: Plug this script into 'GDB_SCRIPT' inside debug.sh or whatever other debug script.
+# Set your 2nd breakpoint to after whatever location that is hanging. If it hangs,
+# the 'echo' will never execute, and now you can examine the state of the system.
+
+# Connect to QEMU
+target remote :1234
+
+# Load symbols
+add-symbol-file kernel/build/kernel.elf 0x80000
+
+# Kill QEMU on GDB exit
+define hook-quit
+  shell pkill -f qemu-system-aarch64
+end
+
+# Set a breakpoint at kernelMain
+b kernelMain
+
+# Set a breakpoint at the HashMap constructor
+b "HashMap<int, int, DefaultIntegerHash>::HashMap(int, double, DefaultIntegerHash const&)"
+
+# Set a breakpoint after all HashMap tests are done
+b hashmapTests.h:34
+
+# Define commands for the HashMap constructor breakpoint:
+#  - "silent" means don't print normal GDB messages
+#  - print a helpful message, then continue again
+commands 2
+  silent
+  echo "\n[DEBUG] >>> Hit HashMap constructor => not stuck in 'new' or 'malloc'.\n"
+  continue
+end
+
+# After loading, immediately continue from kernelMain
+continue

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -17,7 +17,7 @@ OBJCOPY := $(ARMBIN)/aarch64-none-linux-gnu-objcopy 	# Objcopy
 GDB := $(ARMBIN)/aarch64-none-linux-gnu-gdb 					# GDB
 QEMU := $(QEMUBIN)/qemu-system-aarch64 								# QEMU
 
-# Flags and params
+# QEMU flags and params
 QEMU_FLAGS := -no-reboot -M raspi3b -nographic -smp 4
 
 # Optional kernel output log file
@@ -46,19 +46,33 @@ DEPFLAGS = -MMD -MP
 BUILD 	:= build
 SRCDIR 	:= src
 INCDIR 	:= include
-VPATH 	:= $(SRCDIR) $(INCDIR)
 
-# Identify source files
-CSRC 		:= $(wildcard $(SRCDIR)/*.c)
-CXXSRC 	:= $(wildcard $(SRCDIR)/*.cpp)
-ASSRC 	:= $(wildcard $(SRCDIR)/*.s)
+# Dynamically find all subdirectories under include/
+INC_SUBDIRS := $(shell find $(INCDIR) -type d)
+
+# For each subdir in include/, add "-I subdir" to the compiler flags
+INC_PATHS := $(foreach d, $(INC_SUBDIRS), -I $d)
+CCFLAGS   += $(INC_PATHS)
+CXXFLAGS  += $(INC_PATHS)
+
+# Search recursively for all files to build
+CSRC   	:= $(shell find $(SRCDIR) -name '*.c')
+CXXSRC 	:= $(shell find $(SRCDIR) -name '*.cpp')
+ASSRC  	:= $(shell find $(SRCDIR) -name '*.s')
 
 # Produce object lists
 COBJ 		:= $(patsubst $(SRCDIR)/%.c,%.o,$(CSRC))
 CXXOBJ 	:= $(patsubst $(SRCDIR)/%.cpp,%.o,$(CXXSRC))
 ASOBJ 	:= $(patsubst $(SRCDIR)/%.s,%.o,$(ASSRC))
 
-OBJS 		:= $(addprefix $(BUILD)/,$(COBJ) $(CXXOBJ) $(ASOBJ))
+OBJS 		:= $(addprefix $(BUILD)/, $(COBJ) $(CXXOBJ) $(ASOBJ))
+
+# The specialized CRT files must come first/last
+CRTI := $(BUILD)/crti.o
+CRTN := $(BUILD)/crtn.o
+
+# Filter them out of the main OBJ list
+OTHER_OBJS := $(filter-out $(CRTI) $(CRTN), $(OBJS))
 
 EXEC 		:= $(BUILD)/kernel.elf
 IMG 		:= $(BUILD)/kernel8.img
@@ -86,7 +100,7 @@ qemu: $(IMG)
 
 # How to build the final ELF from all objects + linker script
 $(EXEC): linker.ld $(OBJS)
-	$(CXX) -T $< $(CXXFLAGS) -o $@ $(OBJS)
+	$(CXX) -T $< $(CXXFLAGS) -o $@ $(CRTI) -Wl,--start-group $(OTHER_OBJS) -Wl,--end-group $(CRTN)
 
 # How to produce the .img from the ELF
 $(IMG): $(EXEC)
@@ -94,13 +108,16 @@ $(IMG): $(EXEC)
 
 # Rules for building object files from C/C++/Assembly
 # We also generate .d dependency files automatically (-MMD -MP)
-$(BUILD)/%.o : %.c | $(BUILD)
-	$(CC) $(CCFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -I $(INCDIR) -c $< -o $@ -MF $(basename $@).d
+$(BUILD)/%.o : $(SRCDIR)/%.c | $(BUILD)
+	@mkdir -p $(dir $@)
+	$(CC) $(CCFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -c $< -o $@ -MF $(basename $@).d
 
-$(BUILD)/%.o : %.cpp | $(BUILD)
-	$(CXX) $(CXXFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -I $(INCDIR) -c $< -o $@ -MF $(basename $@).d
+$(BUILD)/%.o : $(SRCDIR)/%.cpp | $(BUILD)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -c $< -o $@ -MF $(basename $@).d
 
-$(BUILD)/%.o : %.s | $(BUILD)
+$(BUILD)/%.o : $(SRCDIR)/%.s | $(BUILD)
+	@mkdir -p $(dir $@)
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 # Create the build directory if needed

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,93 +1,108 @@
-# Citations in Makefile
+# Citations
 # https://makefiletutorial.com/
 # https://wiki.osdev.org/Raspberry_Pi_Bare_Bones
+
 # Info on implicit rules and naming conventions:
-# https://www.gnu.org/software/make/manual/make.html#Implicit-Rules Info
+# https://www.gnu.org/software/make/manual/make.html#Implicit-Rules
 
 # Programs
 ARMBIN := /u/gheith/public/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin
 QEMUBIN := /u/hill/Coursework/CS378/tools/qemu/bin
 QEMU_LIBS := /u/hill/Coursework/CS378/tools/glib/lib/x86_64-linux-gnu
-AS := $(ARMBIN)/aarch64-none-linux-gnu-as # Assembler
-CC := $(ARMBIN)/aarch64-none-linux-gnu-gcc # C Compiler
-CXX := $(ARMBIN)/aarch64-none-linux-gnu-g++ # C++ Compiler
-OBJCOPY := $(ARMBIN)/aarch64-none-linux-gnu-objcopy # Objcopy
-GDB := $(ARMBIN)/aarch64-none-linux-gnu-gdb # GDB
-QEMU := $(QEMUBIN)/qemu-system-aarch64
+
+AS := $(ARMBIN)/aarch64-none-linux-gnu-as 						# Assembler
+CC := $(ARMBIN)/aarch64-none-linux-gnu-gcc 						# C Compiler
+CXX := $(ARMBIN)/aarch64-none-linux-gnu-g++ 					# C++ Compiler
+OBJCOPY := $(ARMBIN)/aarch64-none-linux-gnu-objcopy 	# Objcopy
+GDB := $(ARMBIN)/aarch64-none-linux-gnu-gdb 					# GDB
+QEMU := $(QEMUBIN)/qemu-system-aarch64 								# QEMU
+
 # Flags and params
 QEMU_FLAGS := -no-reboot -M raspi3b -nographic -smp 4
+
 CCFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib
-CXXFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib -mno-outline-atomics -fno-builtin -fno-stack-protector -fno-exceptions -fno-rtti -nodefaultlibs -nostartfiles -DDEBUG_ENABLED=$(DEBUG_ENABLED)
+CXXFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib \
+						-mno-outline-atomics -fno-builtin -fno-stack-protector \
+						-fno-exceptions -fno-rtti -nodefaultlibs -nostartfiles \
+						-DDEBUG_ENABLED=$(DEBUG_ENABLED)
 
 ASFLAGS :=
 DEBUG_FLAGS := -g
 OPT_FLAGS := -O2
-# Desired object files, executables names, etc.
-BUILD = build
-SRCDIR = src
-INCDIR = include
-VPATH = $(SRCDIR) $(INCDIR)
-# NOTE(Nate): The wildcard and the vpath could fuck us up here when used
-# together
-CSRC = $(wildcard $(SRCDIR)/*.c)
-COBJ = $(patsubst $(SRCDIR)/%.c,%.o,$(CSRC))
-CXXSRC = $(wildcard $(SRCDIR)/*.cpp)
-CXXOBJ = $(patsubst $(SRCDIR)/%.cpp,%.o,$(CXXSRC))
-ASSRC = $(wildcard $(SRCDIR)/*.s)
-ASOBJ = $(patsubst $(SRCDIR)/%.s,%.o,$(ASSRC))
-SRCS = $(CSRC) $(CXXSRC) $(ASSRC)
-OBJS = $(addprefix $(BUILD)/, $(COBJ) $(CXXOBJ) $(ASOBJ))
-EXEC = $(BUILD)/kernel.elf
-IMG = $(BUILD)/kernel8.img
-TMP_IMG = $(BUILD)/kernel8_tmp.img
-# Flags
+
 DEBUG_ENABLED ?= 0
 
+# For generating dependency files automatically
+DEPFLAGS = -MMD -MP
+
+# Desired directories, object files, executables names, etc.
+BUILD 	:= build
+SRCDIR 	:= src
+INCDIR 	:= include
+VPATH 	:= $(SRCDIR) $(INCDIR)
+
+# Identify source files
+CSRC 		:= $(wildcard $(SRCDIR)/*.c)
+CXXSRC 	:= $(wildcard $(SRCDIR)/*.cpp)
+ASSRC 	:= $(wildcard $(SRCDIR)/*.s)
+
+# Produce object lists
+COBJ 		:= $(patsubst $(SRCDIR)/%.c,%.o,$(CSRC))
+CXXOBJ 	:= $(patsubst $(SRCDIR)/%.cpp,%.o,$(CXXSRC))
+ASOBJ 	:= $(patsubst $(SRCDIR)/%.s,%.o,$(ASSRC))
+
+OBJS 		:= $(addprefix $(BUILD)/,$(COBJ) $(CXXOBJ) $(ASOBJ))
+
+EXEC 		:= $(BUILD)/kernel.elf
+IMG 		:= $(BUILD)/kernel8.img
+
+# ------------------------------------------------------------------------
 .PHONY: all clean debug qemu
 
-# Build an operating system
+# Default rule
 all: $(IMG)
 
-# Set the debug flags and compile
+# Debug build
 debug: OPT_FLAGS = -O0
 debug: CCFLAGS += $(DEBUG_FLAGS)
 debug: CXXFLAGS += $(DEBUG_FLAGS)
 debug: ASFLAGS += $(DEBUG_FLAGS)
 debug: $(IMG)
-	@echo "To debug via gdb: type into another terminal"
-	@echo "$(GDB) kernel/build/kernel.elf"
-	@echo "target remote :1234"
+	@echo "To debug via gdb:"
+	@echo "   $(GDB) $(EXEC)"
+	@echo "   (gdb) target remote :1234"
 	LD_LIBRARY_PATH=$(QEMU_LIBS) $(QEMU) $(QEMU_FLAGS) -kernel $(IMG) -s -S
 
+# Run under QEMU
 qemu: $(IMG)
 	LD_LIBRARY_PATH=$(QEMU_LIBS) $(QEMU) $(QEMU_FLAGS) -kernel $(IMG)
 
-# The executable, a .elf file (eg. kernel.elf)
+# How to build the final ELF from all objects + linker script
 $(EXEC): linker.ld $(OBJS)
 	$(CXX) -T $< $(CXXFLAGS) -o $@ $(OBJS)
 
-# THe image, a .img file (eg. kernel.img)
+# How to produce the .img from the ELF
 $(IMG): $(EXEC)
 	$(OBJCOPY) $< -O binary $@
 
-# NOTE(Nate): Implicit rules are okay... but explicit would be good
-
-# Implicit rule for creating object files from c files
+# Rules for building object files from C/C++/Assembly
+# We also generate .d dependency files automatically (-MMD -MP)
 $(BUILD)/%.o : %.c | $(BUILD)
-	$(CC) $(CCFLAGS) $(OPT_FLAGS) -c $< -o $@ -I $(INCDIR)
+	$(CC) $(CCFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -I $(INCDIR) -c $< -o $@ -MF $(basename $@).d
 
-# Implicit rule for creating object files from c++ files
 $(BUILD)/%.o : %.cpp | $(BUILD)
-	$(CXX) $(CXXFLAGS) $(OPT_FLAGS) -c $< -o $@ -I $(INCDIR)
+	$(CXX) $(CXXFLAGS) $(OPT_FLAGS) $(DEPFLAGS) -I $(INCDIR) -c $< -o $@ -MF $(basename $@).d
 
-# Implicit rule for creating object files from assembly files
 $(BUILD)/%.o : %.s | $(BUILD)
 	$(AS) $(ASFLAGS) -c $< -o $@
 
-# Make the build directory if doesn't exist
+# Create the build directory if needed
 $(BUILD):
-	mkdir $@
+	mkdir -p $@
 
-# All files are in the build dir
+# "make clean" wipes out build/
 clean:
-	$(RM) -rf $(BUILD)
+	rm -rf $(BUILD)
+
+# Pull in automatically generated dependencies, if any
+-include $(OBJS:.o=.d)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -20,17 +20,24 @@ QEMU := $(QEMUBIN)/qemu-system-aarch64 								# QEMU
 # Flags and params
 QEMU_FLAGS := -no-reboot -M raspi3b -nographic -smp 4
 
+# Optional kernel output log file
+QEMU_LOG ?=
+ifneq ($(QEMU_LOG),)
+QEMU_FLAGS += -serial file:../$(QEMU_LOG)
+endif
+
 CCFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib
 CXXFLAGS := -march=armv8-a -mcpu=cortex-a53 -ffreestanding -nostdlib \
 						-mno-outline-atomics -fno-builtin -fno-stack-protector \
 						-fno-exceptions -fno-rtti -nodefaultlibs -nostartfiles \
 						-DDEBUG_ENABLED=$(DEBUG_ENABLED)
 
+# Enable debug prints
+DEBUG_ENABLED ?= 0
+
 ASFLAGS :=
 DEBUG_FLAGS := -g
 OPT_FLAGS := -O2
-
-DEBUG_ENABLED ?= 0
 
 # For generating dependency files automatically
 DEPFLAGS = -MMD -MP

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -3,21 +3,16 @@
 
 #include "kernel.h"
 
-#include "atomics.h"
 #include "cores.h"
 #include "crti.h"
-#include "definitions.h"
 #include "event_loop.h"
 #include "heap.h"
-#include "interrupts.h"
-#include "crti.h"
-#include "physmem.h"
 #include "machine.h"
+#include "physmem.h"
 #include "printf.h"
 #include "stdint.h"
 #include "system_timer.h"
 #include "tester.h"
-#include "uart.h"
 
 extern "C" void kernelMain() {
   // Handled uart Init
@@ -51,5 +46,6 @@ extern "C" void kernelMain() {
 
   event_loop();
 
-  while (1);
+  while (1)
+    ;
 }

--- a/run_until_unexpected.sh
+++ b/run_until_unexpected.sh
@@ -3,33 +3,51 @@
 # This script will continuously run 'make qemu' until the last line of
 # kernel output is different than expected.
 
-MAX_SECS=5   # How many seconds to let QEMU run each time before timing out
+MAX_SECS=3                      # How many seconds to let QEMU run each time before timing out
+EXPECTED_LINE="HERE 4"          # Change this to the line you expect at the end
+LOGFILE="kernel_output.log"     # File to kernel output
+
 COUNTER=0
 
 while true; do
+  # Remove old logs
+  rm -f "$LOGFILE"
+
+  # Run QEMU for MAX_SECS seconds
+  # Need --foreground otherwise QEMU arguments won't be passed in
+  timeout --foreground ${MAX_SECS}s make QEMU_LOG="$LOGFILE" qemu
+
+  # Reset terminal back to cooked mode
+  reset
+
   COUNTER=$((COUNTER + 1))
   echo "=============================================="
   echo "Run #$COUNTER"
   echo "=============================================="
 
-  # Remove old logs
-  rm -f kernel/kernel_output.log
+  # Find the PID of a qemu-system-aarch64 process
+  PID=$(pgrep -f qemu-system-aarch64)
 
-  # Run QEMU via "make qemu" for MAX_SECS seconds
-  # All kernel Output is captured to kernel/kernel_output.log
-  timeout ${MAX_SECS}s make qemu
+  # Kill the QEMU process running in the background since
+  # timeout doesn't kill everything
+  if [ -n "$PID" ]; then
+    echo "Found QEMU PID: $PID"
+    kill "$PID"
+  else
+    echo "No matching QEMU process found."
+  fi
 
-  # Grab the last line of QEMU's output
-  LAST_LINE="$(tail -n 1 qemu_output.log)"
+  # Grab the last line in the kernel output file
+  LAST_LINE="$(tail -n 1 "$LOGFILE")"
 
   echo "Last line of output: '$LAST_LINE'"
 
-  # If it's not "HERE 4", we assume we've hit the deadlock scenario
-  if [ "$LAST_LINE" != "HERE 4" ]; then
-    echo "Deadlock (or unexpected exit) detected in run #$COUNTER!"
+  # If it's not the expected line, something unexpected happened
+  if [ "$LAST_LINE" != "$EXPECTED_LINE" ]; then
+    echo "Unexpected behavior detected in run #$COUNTER!"
     echo "Exiting..."
     exit 1
   fi
 
-  echo "Run #$COUNTER was successful (i.e. ended with 'HERE 4'). Retrying..."
+  echo "Run #$COUNTER was successful (i.e., ended with '$EXPECTED_LINE'). Retrying..."
 done

--- a/run_until_unexpected.sh
+++ b/run_until_unexpected.sh
@@ -6,6 +6,7 @@
 MAX_SECS=3                      # How many seconds to let QEMU run each time before timing out
 EXPECTED_LINE="HERE 4"          # Change this to the line you expect at the end
 LOGFILE="kernel_output.log"     # File to kernel output
+DEBUG_ENABLED_FLAG=1            # Enable debug prints
 
 COUNTER=0
 
@@ -13,9 +14,12 @@ while true; do
   # Remove old logs
   rm -f "$LOGFILE"
 
+  # Make clean
+  make clean
+
   # Run QEMU for MAX_SECS seconds
   # Need --foreground otherwise QEMU arguments won't be passed in
-  timeout --foreground ${MAX_SECS}s make QEMU_LOG="$LOGFILE" qemu
+  timeout --foreground ${MAX_SECS}s make DEBUG_ENABLED=$DEBUG_ENABLED_FLAG QEMU_LOG="$LOGFILE" qemu
 
   # Reset terminal back to cooked mode
   reset

--- a/run_until_unexpected.sh
+++ b/run_until_unexpected.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script will continuously run 'make qemu' until the last line of
+# kernel output is different than expected.
+
+MAX_SECS=5   # How many seconds to let QEMU run each time before timing out
+COUNTER=0
+
+while true; do
+  COUNTER=$((COUNTER + 1))
+  echo "=============================================="
+  echo "Run #$COUNTER"
+  echo "=============================================="
+
+  # Remove old logs
+  rm -f kernel/kernel_output.log
+
+  # Run QEMU via "make qemu" for MAX_SECS seconds
+  # All kernel Output is captured to kernel/kernel_output.log
+  timeout ${MAX_SECS}s make qemu
+
+  # Grab the last line of QEMU's output
+  LAST_LINE="$(tail -n 1 qemu_output.log)"
+
+  echo "Last line of output: '$LAST_LINE'"
+
+  # If it's not "HERE 4", we assume we've hit the deadlock scenario
+  if [ "$LAST_LINE" != "HERE 4" ]; then
+    echo "Deadlock (or unexpected exit) detected in run #$COUNTER!"
+    echo "Exiting..."
+    exit 1
+  fi
+
+  echo "Run #$COUNTER was successful (i.e. ended with 'HERE 4'). Retrying..."
+done


### PR DESCRIPTION
- Changed Makefile to rebuild the source files whose dependencies changed. No need to do `make clean` every time now.
- Added GDB debug script and a script that automates running until unexpected output.
- Optional QEMU flag that redirects all kernel output (only kernel output) to a separate logfile.
- Wrote a script that automates running until an unexpected output occurs.
- Make now auto builds subdirectories. Also handles recursive subdirectories (i.e., a directory within a directory).
- C++ IntelliSense file for recursively auto discovering header include paths (for VS Code). Note: this only works for subdirectories that are only 1 level nested within `kernel/include`, IntelliSense doesn't work well for deeper nested subdirectories.